### PR TITLE
fix(PM-4133):  Removed the availableForGigs for others

### DIFF
--- a/src/services/MemberTraitService.js
+++ b/src/services/MemberTraitService.js
@@ -230,9 +230,11 @@ async function getTraits (currentUser, handle, query) {
       if (item.traitId === 'personalization' && item.traits && item.traits.data) {
         _.forEach(item.traits.data, (dataEntry) => {
           delete dataEntry.links
+          delete dataEntry.availableForGigs
           if (Array.isArray(dataEntry.personalization)) {
             _.forEach(dataEntry.personalization, (each) => {
               delete each.links
+              delete each.availableForGigs
             })
           }
         })


### PR DESCRIPTION
## What's in this PR?

- Removed the availableForGigs for others from traits endpoint, this trait is not used in frontend but openToWork is used but still leaving this for self users.

Ticket link - https://topcoder.atlassian.net/browse/PM-4133

