### PR TITLE
PM-4198 - composite index on (memberTraitId, key)

### DIFF
--- a/prisma/migrations/20260330000000_add_member_trait_personalization_key_index/migration.sql
+++ b/prisma/migrations/20260330000000_add_member_trait_personalization_key_index/migration.sql
@@ -1,0 +1,4 @@
+-- CreateIndex: composite index on (memberTraitId, key) to speed up
+-- EXISTS lookups that filter by userId (via memberTraits join) and key value.
+CREATE INDEX "memberTraitPersonalization_memberTraitId_key_idx"
+ON "members"."memberTraitPersonalization"("memberTraitId", "key");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -500,6 +500,7 @@ model memberTraitPersonalization {
   updatedBy   String?
 
   @@index([memberTraitId])
+  @@index([memberTraitId, key], map: "memberTraitPersonalization_memberTraitId_key_idx")
   @@schema("members")
 }
 


### PR DESCRIPTION
https://topcoder.atlassian.net/browse/PM-4198 - completed profiles report is too slow in prod.
Add composite index on memberTraitPersonalization(memberTraitId, key) for openToWork lookups
