### PR TITLE
PM-5051: Rerate rated Marathon Match challenges

### DIFF
--- a/src/ratings/mmRatingEngine.js
+++ b/src/ratings/mmRatingEngine.js
@@ -25,8 +25,7 @@ const {
 const { runQubitsRating, getRatingColor, DEFAULT_VOLATILITY } = require('./qubitsAlgorithm')
 const {
   RATING_METADATA_SELECT,
-  isChallengeRated,
-  parseBooleanLike
+  isChallengeRated
 } = require('./challengeRatingStatus')
 const {
   challengeMatchesRatingPath,
@@ -896,6 +895,7 @@ async function fetchChallengeMetadataMap (challengeClient, challengeIds) {
  * Build the ordered rerate history for the target member.
  * Multiple submission-level rows for one challenge are collapsed to the latest
  * final system result so the rating pass replays each challenge only once.
+ * Challenge-level rating metadata decides whether the challenge is rated.
  * @param {Array<Object>} mmResultRows submission-level MM result rows
  * @param {Map<string, Object>} challengeMetadataById challenge metadata keyed by id
  * @returns {Array<Object>} ordered challenge history entries for rerating
@@ -904,11 +904,6 @@ function buildTargetHistory (mmResultRows, challengeMetadataById, ratingPath) {
   const historyByChallengeId = new Map()
 
   mmResultRows.forEach((row) => {
-    const rowRated = parseBooleanLike(row.rated)
-    if (rowRated === false) {
-      return
-    }
-
     const challenge = challengeMetadataById.get(String(row.challengeId))
     if (!challenge || !challenge.endDate) {
       return

--- a/test/unit/MmRatingEngine.test.js
+++ b/test/unit/MmRatingEngine.test.js
@@ -656,6 +656,62 @@ describe('marathon match rating engine unit tests', () => {
     state.maxRatingRows.should.have.length(0)
   })
 
+  it('rerateMmTrack should rate MM summations when challenge metadata is rated despite stale row metadata', async () => {
+    const scoringConfig = {
+      relativeScoringEnabled: true,
+      scoreDirection: 'MAXIMIZE'
+    }
+    const { client: membersClient, state } = createMembersClient({
+      historyRows: [],
+      statsRows: [],
+      maxRatingRows: []
+    })
+    const challengeClient = createChallengeClient({
+      [challengeId]: {
+        id: challengeId,
+        endDate: new Date('2024-06-01T00:00:00.000Z'),
+        track: { name: 'DATA_SCIENCE' },
+        type: { name: 'MARATHON_MATCH' },
+        metadata: [{ name: 'isRated', value: 'true' }]
+      }
+    })
+    const staleMetadataRows = baseReviewRows.map((row) => ({
+      ...cloneRow(row),
+      rated: false
+    }))
+    const expectedTargetState = buildExpectedTargetState(
+      targetUserId,
+      opponentUserId,
+      20,
+      10,
+      scoringConfig
+    )
+
+    const result = await rerateMmTrack(
+      membersClient,
+      challengeClient,
+      null,
+      createMmReviewDbClient(staleMetadataRows),
+      targetUserId,
+      challengeId
+    )
+
+    should.equal(result.challengesProcessed, 1)
+    should.equal(result.ratingsUpdated, 1)
+
+    const statsRow = state.statsRows.find((row) =>
+      String(row.userId) === String(targetUserId) &&
+      row.trackId === DATA_SCIENCE_TRACK_ID &&
+      row.typeId === MARATHON_MATCH_TYPE_ID
+    )
+    const historyRow = findHistoryRow(state.historyRows, targetUserId, challengeId)
+
+    should.equal(statsRow.rating, expectedTargetState.rating)
+    should.equal(statsRow.volatility, expectedTargetState.volatility)
+    should.equal(historyRow.newRating, expectedTargetState.rating)
+    should.equal(historyRow.placement, 1)
+  })
+
   it('rerateMmTrack should match review submissions by legacyChallengeId while storing canonical history', async () => {
     const canonicalChallengeId = 'mm-canonical-challenge-id'
     const legacyChallengeId = 30012345


### PR DESCRIPTION
What was broken

Marathon Match rerating skipped a challenge whenever the review summation row carried rated=false, even when the completed challenge metadata marked the challenge as rated.

Root cause

The Marathon Match replay path treated submission-level rating metadata as authoritative before loading the challenge metadata. That allowed stale or backfilled row metadata to suppress the challenge-level rating decision.

What was changed

Marathon Match rerating now relies on challenge-level rating metadata when deciding whether to include a challenge in the replay history, matching the Development rerating path.

Any added/updated tests

Added a Marathon Match unit test proving a challenge with rated challenge metadata still writes stats and history when summation rows contain stale rated=false metadata.

Validation: focused Marathon Match tests passed and lint passed. The full pnpm test command was run; the PM-5051-related suites passed, but existing MemberService and MemberTraitService tests still fail in this checkout because they require additional skills schema/Auth0 bus test setup and contain unrelated existing assertions.
