### PR TITLE
[PROD] PM-4990 - member country indexes

### DIFF
--- a/prisma/migrations/20260513120000_add_member_country_indexes/migration.sql
+++ b/prisma/migrations/20260513120000_add_member_country_indexes/migration.sql
@@ -1,0 +1,15 @@
+-- Partial B-tree index for homeCountryCode lookups (only indexes non-NULL rows)
+CREATE INDEX "idx_member_home_country_code"
+  ON members."member" ("homeCountryCode")
+  WHERE "homeCountryCode" IS NOT NULL;
+
+-- Partial B-tree index for competitionCountryCode lookups (only indexes non-NULL rows)
+CREATE INDEX "idx_member_competition_country_code"
+  ON members."member" ("competitionCountryCode")
+  WHERE "competitionCountryCode" IS NOT NULL;
+
+-- Functional index for case-insensitive country matching via UPPER(country)
+-- Not representable in Prisma schema; managed as a raw migration.
+CREATE INDEX "idx_member_country_upper"
+  ON members."member" (UPPER("country"))
+  WHERE "country" IS NOT NULL;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -81,6 +81,8 @@ model member {
   @@index([lastLoginDate])
   @@index([availableForGigs])
   @@index([status, availableForGigs])
+  @@index([homeCountryCode], map: "idx_member_home_country_code")
+  @@index([competitionCountryCode], map: "idx_member_competition_country_code")
   @@schema("members")
 }
 


### PR DESCRIPTION
https://topcoder.atlassian.net/browse/PM-4990
This pull request adds new database indexes to improve the performance of queries involving country code fields in the `members.member` table. 

* Added partial B-tree indexes for the `homeCountryCode` and `competitionCountryCode` columns in the `members.member` table, indexing only non-NULL values to optimize queries filtering on these fields.
* Added a functional index on the uppercased `country` column to support efficient case-insensitive searches, managed via a raw migration since this is not directly representable in the Prisma schema.
