### PR TITLE
PM-5221: rate Data Science Challenge history

### DIFF
--- a/src/ratings/developRatingEngine.js
+++ b/src/ratings/developRatingEngine.js
@@ -69,6 +69,52 @@ function normalizeChallengeDimension (value) {
 }
 
 /**
+ * Normalize one or more rating-context values into an array.
+ * @param {*} value scalar or array option value
+ * @returns {Array<*>} option values as an array
+ */
+function toRatingContextArray (value) {
+  if (Array.isArray(value)) {
+    return value
+  }
+
+  return value ? [value] : []
+}
+
+/**
+ * Build source challenge filters and target unified dimensions for this rating run.
+ * Defaults preserve the historical DEVELOPMENT / Challenge stream.
+ * @param {Object} [options] rerate options
+ * @param {string} [options.targetTrackName] unified stats track to update
+ * @param {string} [options.targetTypeName] unified stats type to update
+ * @param {Array<string>|string} [options.challengeTrackNames] source challenge tracks to replay
+ * @param {Array<string>|string} [options.challengeTypeNames] source challenge types to replay
+ * @returns {Object} normalized rating context
+ */
+function buildRatingContext (options = {}) {
+  const challengeTrackNames = toRatingContextArray(options.challengeTrackNames || options.challengeTrackName)
+  const challengeTypeNames = toRatingContextArray(options.challengeTypeNames || options.challengeTypeName)
+
+  return {
+    targetTrackName: String(options.targetTrackName || TRACK_NAME).trim() || TRACK_NAME,
+    targetTypeName: String(options.targetTypeName || TYPE_NAME).trim() || TYPE_NAME,
+    challengeTrackNames: (challengeTrackNames.length > 0 ? challengeTrackNames : [CHALLENGE_TRACK_NAME])
+      .map(normalizeChallengeDimension),
+    challengeTypeNames: (challengeTypeNames.length > 0 ? challengeTypeNames : CHALLENGE_TYPE_NAMES)
+      .map(normalizeChallengeDimension)
+  }
+}
+
+/**
+ * Build the human-readable label for rerate errors.
+ * @param {Object} ratingContext normalized rating context
+ * @returns {string} target track/type label
+ */
+function getRatingContextLabel (ratingContext) {
+  return `${ratingContext.targetTrackName}/${ratingContext.targetTypeName}`
+}
+
+/**
  * Add one non-empty challenge id candidate to the supplied set.
  * @param {Set<string>} candidates mutable challenge id candidate set
  * @param {*} value raw challenge id candidate
@@ -150,22 +196,23 @@ function historyEntryMatchesChallengeId (historyEntry, challengeId) {
 }
 
 /**
- * Resolve whether challenge metadata belongs to the Development Challenge rating stream.
- * Development CODE challenge rows are rated into the same DEVELOP / Challenge
- * stream as standard Development Challenge rows.
+ * Resolve whether challenge metadata belongs to the configured Challenge rating stream.
+ * By default, Development CODE challenge rows are rated into the same
+ * DEVELOP / Challenge stream as standard Development Challenge rows.
  * @param {Object} challenge challenge metadata record
+ * @param {Object} [ratingContext] normalized rating context
  * @returns {boolean} true when the challenge should be replayed by this engine
  */
-function isDevelopmentRatingChallenge (challenge) {
+function isDevelopmentRatingChallenge (challenge, ratingContext = buildRatingContext()) {
   if (!challenge || !challenge.track || !challenge.type) {
     return false
   }
 
   const normalizedTrackName = normalizeChallengeDimension(challenge.track.name)
   const normalizedTypeName = normalizeChallengeDimension(challenge.type.name)
-  const supportedTypeNames = CHALLENGE_TYPE_NAMES.map(normalizeChallengeDimension)
 
-  return normalizedTrackName === CHALLENGE_TRACK_NAME && supportedTypeNames.includes(normalizedTypeName)
+  return ratingContext.challengeTrackNames.includes(normalizedTrackName) &&
+    ratingContext.challengeTypeNames.includes(normalizedTypeName)
 }
 
 function isCompletedChallenge (challenge) {
@@ -246,24 +293,25 @@ function buildUserStateKey (userId) {
 }
 
 /**
- * Resolve the unified track/type UUIDs used for DEVELOPMENT / Challenge rows.
+ * Resolve the unified track/type UUIDs used for this challenge-result rating stream.
  * @param {Object} challengeClient prisma challenge client
+ * @param {Object} [ratingContext] normalized rating context
  * @returns {Promise<{trackId: string, typeId: string, trackName: string, typeName: string, dimensionLookup: Object}>} resolved unified ids
  */
-async function resolveUnifiedDimensionIds (challengeClient) {
+async function resolveUnifiedDimensionIds (challengeClient, ratingContext = buildRatingContext()) {
   const dimensionLookup = await loadChallengeDimensionLookup(challengeClient)
-  const trackId = resolveTrackIdFromLookup(dimensionLookup, TRACK_NAME)
-  const typeId = resolveTypeIdFromLookup(dimensionLookup, TYPE_NAME)
+  const trackId = resolveTrackIdFromLookup(dimensionLookup, ratingContext.targetTrackName)
+  const typeId = resolveTypeIdFromLookup(dimensionLookup, ratingContext.targetTypeName)
 
   if (!trackId || !typeId) {
-    throw new Error(`Unable to resolve unified dimension ids for ${TRACK_NAME}/${TYPE_NAME}`)
+    throw new Error(`Unable to resolve unified dimension ids for ${getRatingContextLabel(ratingContext)}`)
   }
 
   return {
     trackId,
     typeId,
-    trackName: TRACK_NAME,
-    typeName: TYPE_NAME,
+    trackName: ratingContext.targetTrackName,
+    typeName: ratingContext.targetTypeName,
     dimensionLookup
   }
 }
@@ -548,10 +596,12 @@ function isCanonicalReviewChallengeRow (row, challenge) {
  * @param {Object} [options] history filtering options
  * @param {boolean} [options.skipLegacyReviewIds=false] ignore legacy numeric review ids that are already represented by legacy subtrack history
  * @param {boolean} [options.useLegacySourceRatings=false] preserve challengeResult oldRating/newRating for legacy-backed rows
+ * @param {Object} [options.ratingContext] source and target dimension config
  * @returns {Array<Object>} ordered challenge history entries for rerating
  */
 function buildTargetHistory (reviewRows, challengeMetadataById, options = {}) {
   const historyByChallengeId = new Map()
+  const ratingContext = options.ratingContext || buildRatingContext()
 
   reviewRows.forEach((row) => {
     if (!isParticipantEligibleForRating(row)) {
@@ -575,7 +625,7 @@ function buildTargetHistory (reviewRows, challengeMetadataById, options = {}) {
       return
     }
 
-    if (!isDevelopmentRatingChallenge(challenge)) {
+    if (!isDevelopmentRatingChallenge(challenge, ratingContext)) {
       return
     }
 
@@ -942,6 +992,10 @@ async function refreshMostRecentHistoryFlag (tx, userId, dimensionIds) {
  * @param {boolean} [options.recalculateRanks=true] recompute Develop Challenge ranks after this member rerate
  * @param {boolean} [options.skipLegacyReviewIds=false] skip legacy numeric challengeResult aliases during full migration rerates
  * @param {boolean} [options.useLegacySourceRatings=false] preserve challengeResult oldRating/newRating for legacy-backed rows
+ * @param {string} [options.targetTrackName=DEVELOP] unified stats track to update
+ * @param {string} [options.targetTypeName=Challenge] unified stats type to update
+ * @param {Array<string>|string} [options.challengeTrackNames=DEVELOPMENT] source challenge tracks to replay
+ * @param {Array<string>|string} [options.challengeTypeNames=[Challenge,CODE]] source challenge types to replay
  * @returns {Promise<{challengesProcessed: number, ratingsUpdated: number}>} rerate counters
  * @throws {Error} when required review DB or dimension data is unavailable
  */
@@ -951,6 +1005,7 @@ async function rerateDevTrack (membersClient, challengeClient, reviewDbClient, u
   }
 
   const normalizedUserId = toBigIntUserId(userId)
+  const ratingContext = buildRatingContext(options)
   const reviewRows = await fetchReviewResultsForUser(reviewDbClient, normalizedUserId)
   if (reviewRows.length === 0) {
     return {
@@ -966,7 +1021,8 @@ async function rerateDevTrack (membersClient, challengeClient, reviewDbClient, u
 
   const targetHistory = buildTargetHistory(reviewRows, challengeMetadataById, {
     skipLegacyReviewIds: options.skipLegacyReviewIds === true,
-    useLegacySourceRatings: options.useLegacySourceRatings === true
+    useLegacySourceRatings: options.useLegacySourceRatings === true,
+    ratingContext
   })
   if (targetHistory.length === 0) {
     return {
@@ -975,13 +1031,14 @@ async function rerateDevTrack (membersClient, challengeClient, reviewDbClient, u
     }
   }
 
-  const dimensionIds = await resolveUnifiedDimensionIds(challengeClient)
+  const dimensionIds = await resolveUnifiedDimensionIds(challengeClient, ratingContext)
+  const ratingLabel = getRatingContextLabel(ratingContext)
 
   let startIndex = 0
   if (fromChallengeId) {
     startIndex = targetHistory.findIndex((entry) => historyEntryMatchesChallengeId(entry, fromChallengeId))
     if (startIndex < 0) {
-      throw new errors.BadRequestError(`Challenge ${fromChallengeId} is not a rated ${TRACK_NAME}/${TYPE_NAME} event for this member`)
+      throw new errors.BadRequestError(`Challenge ${fromChallengeId} is not a rated ${ratingLabel} event for this member`)
     }
   }
 

--- a/src/services/StatisticsService.js
+++ b/src/services/StatisticsService.js
@@ -66,6 +66,7 @@ if (!_.includes(SUPPORTED_STATS_READ_SOURCES, configuredStatsReadSource)) {
 }
 const USE_LEGACY_STATS_READS = configuredStatsReadSource === LEGACY_STATS_READ_SOURCE
 const RATING_SOURCE_DEVELOPMENT = 'DEVELOPMENT_CHALLENGE'
+const RATING_SOURCE_DATA_SCIENCE_CHALLENGE = 'DATA_SCIENCE_CHALLENGE'
 const RATING_SOURCE_MARATHON_MATCH = 'MARATHON_MATCH'
 const RERATE_MARATHON_ACTOR = 'rerate-mm-stats'
 const CHALLENGE_WINNER_PLACEMENT_TYPE = 'PLACEMENT'
@@ -435,6 +436,10 @@ function resolveChallengeRatingSource (challenge) {
     return RATING_SOURCE_DEVELOPMENT
   }
 
+  if (trackName === TRACK_NAMES.DATA_SCIENCE && typeName === TYPE_NAMES.CHALLENGE) {
+    return RATING_SOURCE_DATA_SCIENCE_CHALLENGE
+  }
+
   if (trackName === TRACK_NAMES.DATA_SCIENCE && typeName === TYPE_NAMES.MARATHON_MATCH) {
     return RATING_SOURCE_MARATHON_MATCH
   }
@@ -457,6 +462,14 @@ function buildBaseRatingJob (challenge, source) {
     return {
       source,
       trackId: TRACK_NAMES.DEVELOP,
+      typeId: TYPE_NAMES.CHALLENGE
+    }
+  }
+
+  if (source === RATING_SOURCE_DATA_SCIENCE_CHALLENGE) {
+    return {
+      source,
+      trackId: TRACK_NAMES.DATA_SCIENCE,
       typeId: TYPE_NAMES.CHALLENGE
     }
   }
@@ -635,13 +648,24 @@ async function rerateChallengeRatingJobForMember (challengeClient, reviewDbClien
     )
   }
 
-  if (job.source === RATING_SOURCE_DEVELOPMENT) {
+  if (job.source === RATING_SOURCE_DEVELOPMENT ||
+    job.source === RATING_SOURCE_DATA_SCIENCE_CHALLENGE) {
+    const rerateOptions = job.source === RATING_SOURCE_DATA_SCIENCE_CHALLENGE
+      ? {
+        targetTrackName: TRACK_NAMES.DATA_SCIENCE,
+        targetTypeName: TYPE_NAMES.CHALLENGE,
+        challengeTrackNames: [TRACK_NAMES.DATA_SCIENCE],
+        challengeTypeNames: [TYPE_NAMES.CHALLENGE]
+      }
+      : undefined
+
     return rerateDevTrack(
       prisma,
       challengeClient,
       reviewDbClient,
       userId,
-      challengeId
+      challengeId,
+      rerateOptions
     )
   }
 
@@ -4289,8 +4313,9 @@ rerateChallengeSubmitterRatings.schema = {
 }
 
 /**
- * Trigger a DEVELOPMENT / Challenge, DATA_SCIENCE / MARATHON_MATCH, or configured
- * tag- or skill-based rating path re-rating pass beginning with the supplied challenge.
+ * Trigger a DEVELOPMENT / Challenge, DATA_SCIENCE / Challenge,
+ * DATA_SCIENCE / MARATHON_MATCH, or configured tag- or skill-based rating path
+ * re-rating pass beginning with the supplied challenge.
  * The relevant review-api results are reprocessed in chronological order and
  * persisted into the existing unified rating tables for the member.
  * @param {Object} currentUser the user who performs operation
@@ -4333,6 +4358,20 @@ async function rerateMemberStats (currentUser, handle, data) {
       member.userId,
       payload.challengeId
     )
+  } else if (trackId === TRACK_NAMES.DATA_SCIENCE && typeId === TYPE_NAMES.CHALLENGE) {
+    result = await rerateDevTrack(
+      prisma,
+      challengeClient,
+      reviewDbClient,
+      member.userId,
+      payload.challengeId,
+      {
+        targetTrackName: TRACK_NAMES.DATA_SCIENCE,
+        targetTypeName: TYPE_NAMES.CHALLENGE,
+        challengeTrackNames: [TRACK_NAMES.DATA_SCIENCE],
+        challengeTypeNames: [TYPE_NAMES.CHALLENGE]
+      }
+    )
   } else if (trackId === TRACK_NAMES.DATA_SCIENCE && typeId === TYPE_NAMES.MARATHON_MATCH) {
     result = await rerateMmTrack(
       prisma,
@@ -4343,7 +4382,7 @@ async function rerateMemberStats (currentUser, handle, data) {
       payload.challengeId
     )
   } else {
-    throw new errors.BadRequestError('Only DEVELOP / Challenge and DATA_SCIENCE / MARATHON_MATCH rerates are currently supported.')
+    throw new errors.BadRequestError('Only DEVELOP / Challenge, DATA_SCIENCE / Challenge, and DATA_SCIENCE / MARATHON_MATCH rerates are currently supported.')
   }
 
   return {

--- a/test/unit/DevelopRatingEngine.test.js
+++ b/test/unit/DevelopRatingEngine.test.js
@@ -422,6 +422,96 @@ function findHistoryRow (historyRows, userId, challengeId) {
 }
 
 describe('develop rating engine unit tests', () => {
+  it('rerateDevTrack should support Data Science Challenge rating dimensions', async () => {
+    const targetUserId = toBigInt(1001)
+    const opponentUserId = toBigInt(2002)
+    const challengeId = 'ds-challenge-1'
+    const eventDate = new Date('2026-06-02T05:30:04.536Z')
+    const members = createMembersClient({
+      historyRows: [],
+      statsRows: [],
+      maxRatingRows: []
+    })
+    const reviewDbClient = createReviewDbClient([
+      {
+        challengeId,
+        userId: targetUserId,
+        finalScore: 100,
+        placement: 1,
+        rated: true,
+        createdAt: new Date('2026-06-02T04:49:42.752Z')
+      },
+      {
+        challengeId,
+        userId: opponentUserId,
+        finalScore: 88.89,
+        placement: 2,
+        rated: true,
+        createdAt: new Date('2026-06-02T04:46:08.538Z')
+      }
+    ])
+    const challengeClient = createChallengeClient({
+      [challengeId]: {
+        id: challengeId,
+        endDate: eventDate,
+        track: { name: 'Data Science' },
+        type: { name: 'Challenge' }
+      }
+    })
+    const expectedParticipants = [
+      createParticipant(targetUserId, 0, 0, 0, 100),
+      createParticipant(opponentUserId, 0, 0, 0, 88.89)
+    ]
+    runQubitsRating(expectedParticipants)
+    const expectedTarget = expectedParticipants.find((participant) => participant.coderId === String(targetUserId))
+
+    const result = await rerateDevTrack(
+      members.client,
+      challengeClient,
+      reviewDbClient,
+      targetUserId,
+      challengeId,
+      {
+        targetTrackName: 'DATA_SCIENCE',
+        targetTypeName: 'Challenge',
+        challengeTrackNames: ['DATA_SCIENCE'],
+        challengeTypeNames: ['Challenge']
+      }
+    )
+
+    result.challengesProcessed.should.equal(1)
+    result.ratingsUpdated.should.equal(1)
+
+    const statsRow = members.state.statsRows.find((row) =>
+      String(row.userId) === String(targetUserId) &&
+      row.trackId === DATA_SCIENCE_TRACK_ID &&
+      row.typeId === CHALLENGE_TYPE_ID
+    )
+    should.exist(statsRow)
+    statsRow.rating.should.equal(expectedTarget.rating)
+    statsRow.volatility.should.equal(expectedTarget.volatility)
+    statsRow.challenges.should.equal(1)
+    statsRow.mostRecentEventDate.should.deep.equal(eventDate)
+
+    const historyRow = findHistoryRow(members.state.historyRows, targetUserId, challengeId)
+    should.exist(historyRow)
+    historyRow.trackId.should.equal(DATA_SCIENCE_TRACK_ID)
+    historyRow.typeId.should.equal(CHALLENGE_TYPE_ID)
+    historyRow.newRating.should.equal(expectedTarget.rating)
+    historyRow.mostRecent.should.equal(true)
+
+    const maxRatingRow = members.state.maxRatingRows.find((row) => String(row.userId) === String(targetUserId))
+    should.exist(maxRatingRow)
+    maxRatingRow.rating.should.equal(expectedTarget.rating)
+    maxRatingRow.track.should.equal('DATA_SCIENCE')
+    maxRatingRow.subTrack.should.equal('Challenge')
+    maxRatingRow.ratingColor.should.equal(getRatingColor(expectedTarget.rating))
+
+    members.state.rankRecalculationCalls.should.have.length(1)
+    members.state.rankRecalculationCalls[0].trackId.should.equal(DATA_SCIENCE_TRACK_ID)
+    members.state.rankRecalculationCalls[0].typeId.should.equal(CHALLENGE_TYPE_ID)
+  })
+
   it('rerateDevTrack should seed rerates from prior history instead of current snapshots', async () => {
     const targetUserId = toBigInt(1001)
     const opponentUserId = toBigInt(2002)

--- a/test/unit/StatisticsService.test.js
+++ b/test/unit/StatisticsService.test.js
@@ -863,6 +863,86 @@ describe('statistics service unit tests', () => {
     }
   })
 
+  it('rerateChallengeSubmitterRatings should rerate Data Science Challenge submitters', async () => {
+    const dsRerateCalls = []
+    const { service, restore } = loadStatisticsService({
+      challengeRow: {
+        id: 'ds-target-challenge',
+        status: 'COMPLETED',
+        endDate: new Date('2026-06-02T05:30:04.536Z'),
+        trackId: 'track-ds-id',
+        typeId: 'type-challenge-id',
+        track: { name: 'Data Science' },
+        type: { name: 'Challenge' },
+        tags: [],
+        skills: [],
+        metadata: []
+      },
+      reviewRows: [
+        { challengeId: 'ds-target-challenge', userId: '101', finalScore: 100, placement: 1 },
+        { challengeId: 'ds-target-challenge', userId: '102', finalScore: 88.89, placement: 2 }
+      ],
+      prismaStub: {
+        member: {
+          findMany: async ({ where }) => where.userId.in.map((userId) => ({ userId }))
+        }
+      },
+      rerateDevTrack: async (membersClient, challengeClient, reviewDbClient, userId, challengeId, options) => {
+        dsRerateCalls.push({
+          userId: String(userId),
+          challengeId,
+          options
+        })
+        return {
+          challengesProcessed: 1,
+          ratingsUpdated: 1
+        }
+      }
+    })
+
+    try {
+      const result = await service.rerateChallengeSubmitterRatings({ isMachine: true }, {
+        challengeId: 'ds-target-challenge'
+      })
+
+      result.rerated.should.equal(true)
+      result.membersProcessed.should.equal(2)
+      result.ratingsAttempted.should.equal(2)
+      result.ratingsUpdated.should.equal(2)
+      result.participantIds.should.deep.equal(['101', '102'])
+      result.ratings.should.deep.equal([
+        {
+          trackId: 'DATA_SCIENCE',
+          typeId: 'Challenge'
+        }
+      ])
+      dsRerateCalls.should.deep.equal([
+        {
+          userId: '101',
+          challengeId: 'ds-target-challenge',
+          options: {
+            targetTrackName: 'DATA_SCIENCE',
+            targetTypeName: 'Challenge',
+            challengeTrackNames: ['DATA_SCIENCE'],
+            challengeTypeNames: ['Challenge']
+          }
+        },
+        {
+          userId: '102',
+          challengeId: 'ds-target-challenge',
+          options: {
+            targetTrackName: 'DATA_SCIENCE',
+            targetTypeName: 'Challenge',
+            challengeTrackNames: ['DATA_SCIENCE'],
+            challengeTypeNames: ['Challenge']
+          }
+        }
+      ])
+    } finally {
+      restore()
+    }
+  })
+
   it('rerateChallengeSubmitterRatings should include Marathon Match final summation submitters when result rows are partial', async () => {
     const mmRerateCalls = []
     const { service, restore } = loadStatisticsService({


### PR DESCRIPTION
What was broken
Completed Data Science / Challenge events were skipped by the member stats rerate endpoint, so submitters could receive profile history cards without rating data and the challenge completion hook reported no supported ratings.

Root cause (if identifiable)
The rerate source resolver only recognized Development / Challenge and Data Science / Marathon Match native ratings. The challenge-result rating engine also hardcoded its source and storage dimensions to Development / Challenge.

What was changed
Added Data Science / Challenge as a native rating source and parameterized the challenge-result rating replay so it can store ratings and history under DATA_SCIENCE / Challenge while preserving the existing Development behavior.

Any added/updated tests
Added unit coverage for rerating Data Science Challenge submitters through the completion endpoint and for persisting Data Science Challenge ratings/history in the rating engine.
