### PR TITLE
PM-5278: Count availability as profile complete

### DIFF
--- a/src/services/MemberService.js
+++ b/src/services/MemberService.js
@@ -55,6 +55,33 @@ const SENDGRID_EMAIL_ACTIVITY_LOOKBACK_DAYS = 30
 const SENDGRID_EMAIL_ACTIVITY_RESULT_LIMIT = 20
 
 /**
+ * Determine whether the member has completed engagement availability.
+ * A member completes this section by either choosing not to be open to work,
+ * or by choosing to be open to work with an availability value. Legacy data
+ * with nested preferred roles is still accepted as complete.
+ * @param {Object} member the member profile data
+ * @param {Object} openToWorkData the personalization open-to-work trait value
+ * @returns {Boolean} true when engagement availability is complete
+ */
+function isEngagementAvailabilityComplete (member, openToWorkData) {
+  if (!openToWorkData) {
+    return false
+  }
+
+  const hasAvailability = !!openToWorkData.availability
+  const hasLegacyPreferredRoles = !!(
+    openToWorkData.preferredRoles &&
+    openToWorkData.preferredRoles.length
+  )
+
+  if (member.availableForGigs === false) {
+    return true
+  }
+
+  return hasAvailability || hasLegacyPreferredRoles
+}
+
+/**
  * Resolve compact memberStats track/type UUIDs before deriving current
  * maxRating labels for member profile responses.
  * @param {Object} member member payload that may include compact memberStats rows
@@ -568,7 +595,7 @@ async function getProfileCompleteness (currentUser, handle, query) {
   const memberTraits = await memberTraitService.getTraits(currentUser, handle, {})
   // Avoid getting the member stats, since we don't need them here, and performance is
   // better without them
-  const memberFields = { 'fields': 'userId,handle,handleLower,photoURL,description,skills,verified,lastProfileConfirmationDate,updatedAt,addresses' }
+  const memberFields = { 'fields': 'userId,handle,handleLower,photoURL,description,skills,verified,lastProfileConfirmationDate,updatedAt,availableForGigs,addresses' }
   const member = await getMemberData(handle, memberFields)
 
   // Used for calculating the percentComplete
@@ -620,10 +647,7 @@ async function getProfileCompleteness (currentUser, handle, query) {
       const openToWorkTrait = item.traits.data.find(r => Object.keys(r).includes('openToWork')) || {}
       const openToWorkData = openToWorkTrait.openToWork
 
-      if (openToWorkData && (
-        !openToWorkData.availability ||
-        (openToWorkData.preferredRoles && openToWorkData.preferredRoles.length)
-      )) {
+      if (isEngagementAvailabilityComplete(member, openToWorkData)) {
         completeItems += 1
         data.engagementAvailability = true
         data.engagementAvailabilityLastUpdateDate = new Date(item.updatedAt).toISOString()

--- a/test/unit/MemberService.test.js
+++ b/test/unit/MemberService.test.js
@@ -19,6 +19,7 @@ process.env.RESOURCES_DB_URL = process.env.RESOURCES_DB_URL || placeholderDbUrl
 process.env.ENGAGEMENTS_DB_URL = process.env.ENGAGEMENTS_DB_URL || placeholderDbUrl
 
 const service = require('../../src/services/MemberService')
+const prisma = require('../../src/common/prisma').getClient()
 const testHelper = require('../testHelper')
 
 const should = chai.should()
@@ -190,6 +191,50 @@ describe('member service unit tests', () => {
         return
       }
       throw new Error('should not reach here')
+    })
+  })
+
+  describe('get profile completeness tests', () => {
+    it('counts open-to-work availability complete without legacy preferred roles', async () => {
+      const memberTraits = await prisma.memberTraits.findUnique({
+        where: { userId: member1.userId }
+      })
+
+      try {
+        await prisma.member.update({
+          where: { userId: member1.userId },
+          data: { availableForGigs: true }
+        })
+
+        await prisma.memberTraitPersonalization.create({
+          data: {
+            memberTraitId: memberTraits.id,
+            key: 'openToWork',
+            value: { availability: 'FULL_TIME' },
+            private: true,
+            createdBy: 'test'
+          }
+        })
+
+        const result = await service.getProfileCompleteness({ isMachine: true }, member1.handle, {})
+
+        should.equal(result.data.engagementAvailability, true)
+        should.equal(result.data.percentComplete, 0.5)
+      } finally {
+        if (memberTraits) {
+          await prisma.memberTraitPersonalization.deleteMany({
+            where: {
+              memberTraitId: memberTraits.id,
+              key: 'openToWork'
+            }
+          })
+        }
+
+        await prisma.member.update({
+          where: { userId: member1.userId },
+          data: { availableForGigs: null }
+        })
+      }
     })
   })
 


### PR DESCRIPTION
What was broken
Profiles that saved open-to-work availability after preferred roles were removed could still be reported as incomplete with the engagement availability prompt.

Root cause
getProfileCompleteness only treated engagement availability as complete when availability was absent or legacy nested preferred roles were present, so current open-to-work records with an availability value and no preferred roles were missed.

What was changed
Added a small engagement-availability completeness helper that accepts an explicit not-open-to-work choice, current availability values, and legacy nested preferred roles. The profile completeness lookup now includes availableForGigs for that decision.

Any added/updated tests
Added a MemberService regression test for open-to-work availability without legacy preferred roles.

Validation notes:
- pnpm lint passed.
- Focused regression test passed.
- pnpm test was run and completed with 172 passing and 14 unrelated baseline failures in existing tests.
- pnpm build was run but this package has no build command.
