### PR TITLE
PM-5222: Use challenge result scores for Dev MM rerates

### DIFF
--- a/src/ratings/mmRatingEngine.js
+++ b/src/ratings/mmRatingEngine.js
@@ -880,14 +880,15 @@ function isEligibleMmSubmissionStatus (value) {
 /**
  * Resolve the best available Marathon Match score from a review result row.
  * Positive aggregate scores keep the higher-precision summation value, while
- * positive submission final scores recover legacy rows whose aggregateScore is
- * a zero or -1 placeholder.
+ * positive submission or challengeResult final scores recover rows whose
+ * aggregateScore is a zero or -1 placeholder.
  * @param {Object} row candidate result row
  * @returns {number} score value, or NaN when no numeric score is available
  */
 function getMmResultScore (row) {
   const aggregateScore = Number(row && row.aggregateScore)
   const finalScore = Number(row && row.finalScore)
+  const challengeResultFinalScore = Number(row && row.challengeResultFinalScore)
 
   if (Number.isFinite(aggregateScore) && aggregateScore > 0) {
     return aggregateScore
@@ -895,6 +896,10 @@ function getMmResultScore (row) {
 
   if (Number.isFinite(finalScore) && finalScore > 0) {
     return finalScore
+  }
+
+  if (Number.isFinite(challengeResultFinalScore) && challengeResultFinalScore > 0) {
+    return challengeResultFinalScore
   }
 
   return aggregateScore
@@ -1081,6 +1086,7 @@ function buildHistoryResultFields (participants, targetUserKey, sourceRow) {
 async function fetchMmResultsForUser (reviewDbClient, userId) {
   const reviewSummationRelation = await resolveReviewDbRelation(reviewDbClient, 'reviewSummation')
   const submissionRelation = await resolveReviewDbRelation(reviewDbClient, 'submission')
+  const challengeResultRelation = await resolveChallengeResultRelation(reviewDbClient)
   const result = await reviewDbClient.query(
     `
       WITH "latestSubmissionSummation" AS (
@@ -1118,23 +1124,41 @@ async function fetchMmResultsForUser (reviewDbClient, userId) {
           AND (s."challengeId" IS NOT NULL OR s."legacyChallengeId" IS NOT NULL)
           AND rs."isFinal" IS NOT FALSE
           ${READY_MM_REVIEW_SUMMATION_FILTER}
+      ),
+      "challengeResultScore" AS (
+        SELECT DISTINCT ON ("challengeId")
+          "challengeId",
+          "placement",
+          "finalScore"
+        FROM ${challengeResultRelation}
+        WHERE "userId" IS NOT NULL
+          AND "userId"::text = $1
+          AND "validSubmission" IS DISTINCT FROM FALSE
+          AND (
+            "finalScore" IS NOT NULL OR
+            ("placement" IS NOT NULL AND "placement" > 0)
+          )
+        ORDER BY "challengeId", "placement" ASC NULLS LAST, "finalScore" DESC NULLS LAST, "createdAt" DESC
       )
       SELECT
-        "submissionId",
-        "memberId",
-        "challengeId",
-        "legacyChallengeId",
-        "placement",
-        "finalScore",
-        "submissionStatus",
-        "submissionCreatedAt",
-        "aggregateScore",
-        "reviewedDate",
-        "createdAt",
-        "rated"
-      FROM "latestSubmissionSummation"
-      WHERE "summationRank" = 1
-      ORDER BY COALESCE("reviewedDate", "createdAt") ASC, "submissionId" ASC
+        lss."submissionId",
+        lss."memberId",
+        lss."challengeId",
+        lss."legacyChallengeId",
+        COALESCE(crs."placement", lss."placement") AS "placement",
+        lss."finalScore",
+        crs."finalScore" AS "challengeResultFinalScore",
+        lss."submissionStatus",
+        lss."submissionCreatedAt",
+        lss."aggregateScore",
+        lss."reviewedDate",
+        lss."createdAt",
+        lss."rated"
+      FROM "latestSubmissionSummation" lss
+      LEFT JOIN "challengeResultScore" crs
+        ON crs."challengeId" = lss."challengeId"
+      WHERE lss."summationRank" = 1
+      ORDER BY COALESCE(lss."reviewedDate", lss."createdAt") ASC, lss."submissionId" ASC
     `,
     [String(userId), VALID_MM_SUBMISSION_STATUSES]
   )
@@ -1199,32 +1223,37 @@ async function fetchMmParticipantsForChallenge (reviewDbClient, challengeId) {
           AND rs."isFinal" IS NOT FALSE
           ${READY_MM_REVIEW_SUMMATION_FILTER}
       ),
-      "challengeResultPlacement" AS (
+      "challengeResultScore" AS (
         SELECT DISTINCT ON ("userId")
           "userId",
-          "placement"
+          "placement",
+          "finalScore"
         FROM ${challengeResultRelation}
         WHERE "challengeId" = ANY($1::text[])
           AND "userId" IS NOT NULL
-          AND "placement" IS NOT NULL
-          AND "placement" > 0
-        ORDER BY "userId", "createdAt" DESC
+          AND "validSubmission" IS DISTINCT FROM FALSE
+          AND (
+            "finalScore" IS NOT NULL OR
+            ("placement" IS NOT NULL AND "placement" > 0)
+          )
+        ORDER BY "userId", "placement" ASC NULLS LAST, "finalScore" DESC NULLS LAST, "createdAt" DESC
       )
       SELECT
         lss."submissionId",
         lss."memberId",
         lss."challengeId",
         lss."legacyChallengeId",
-        COALESCE(crp."placement", lss."placement") AS "placement",
+        COALESCE(crs."placement", lss."placement") AS "placement",
         lss."finalScore",
+        crs."finalScore" AS "challengeResultFinalScore",
         lss."submissionStatus",
         lss."aggregateScore",
         lss."reviewedDate",
         lss."createdAt",
         lss."submissionCreatedAt"
       FROM "latestSubmissionSummation" lss
-      LEFT JOIN "challengeResultPlacement" crp
-        ON crp."userId"::text = lss."memberId"::text
+      LEFT JOIN "challengeResultScore" crs
+        ON crs."userId"::text = lss."memberId"::text
       WHERE lss."summationRank" = 1
       ORDER BY lss."submissionCreatedAt" ASC, lss."submissionId" ASC
     `,

--- a/test/unit/MmRatingEngine.test.js
+++ b/test/unit/MmRatingEngine.test.js
@@ -1882,6 +1882,74 @@ describe('marathon match rating engine unit tests', () => {
     should.equal(historyRow.placement, 1)
   })
 
+  it('rerateMmTrack should use challengeResult score when a Development-track MM summation score is a placeholder', async () => {
+    const developmentTrackMmMetadata = {
+      [challengeId]: {
+        id: challengeId,
+        endDate: new Date('2024-06-01T00:00:00.000Z'),
+        track: { name: 'Development' },
+        type: { name: 'Marathon Match' },
+        metadata: []
+      }
+    }
+    const placeholderScoreRows = [
+      {
+        submissionId: 'submission-target-placeholder-score',
+        memberId: targetUserId,
+        challengeId,
+        placement: 1,
+        aggregateScore: -1,
+        finalScore: 0,
+        challengeResultFinalScore: 100,
+        reviewedDate: new Date('2024-06-01T10:00:00.000Z'),
+        createdAt: new Date('2024-06-01T10:00:00.000Z'),
+        submissionCreatedAt: new Date('2024-06-01T09:00:00.000Z')
+      },
+      {
+        submissionId: 'submission-opponent-scored',
+        memberId: opponentUserId,
+        challengeId,
+        aggregateScore: 80,
+        reviewedDate: new Date('2024-06-01T10:05:00.000Z'),
+        createdAt: new Date('2024-06-01T10:05:00.000Z'),
+        submissionCreatedAt: new Date('2024-06-01T09:05:00.000Z')
+      }
+    ]
+    const expectedParticipants = [
+      createParticipant(targetUserId, 0, 0, 0, 100),
+      createParticipant(opponentUserId, 0, 0, 0, 80)
+    ]
+    runQubitsRating(expectedParticipants)
+    const expectedTargetState = expectedParticipants.find((participant) => participant.coderId === String(targetUserId))
+    const { client: membersClient, state } = createMembersClient({
+      historyRows: [],
+      statsRows: [],
+      maxRatingRows: []
+    })
+
+    const result = await rerateMmTrack(
+      membersClient,
+      createChallengeClient(developmentTrackMmMetadata),
+      null,
+      createMmReviewDbClient(placeholderScoreRows),
+      targetUserId,
+      challengeId
+    )
+
+    should.equal(result.challengesProcessed, 1)
+    should.equal(result.ratingsUpdated, 1)
+    const statsRow = state.statsRows.find((row) =>
+      String(row.userId) === String(targetUserId) &&
+      row.trackId === DATA_SCIENCE_TRACK_ID &&
+      row.typeId === MARATHON_MATCH_TYPE_ID
+    )
+    const historyRow = findHistoryRow(state.historyRows, targetUserId, challengeId)
+
+    should.equal(statsRow.rating, expectedTargetState.rating)
+    should.equal(historyRow.newRating, expectedTargetState.rating)
+    should.equal(historyRow.placement, 1)
+  })
+
   it('rerateMmTrack should replay tagged Development Challenge and MM events under the configured destination track', async () => {
     const priorChallengeId = 'ai-prior-development-challenge'
     const targetChallengeId = 'ai-target-challenge'


### PR DESCRIPTION
What was broken
Development-track Marathon Match rerates could calculate ratings from review summation placeholder scores even when the completed review result had the correct final score. This could make a first-place 100 score look like a very low or floor rating in member stats.

Root cause
The native Marathon Match rerate flow loaded placement data from challengeResult but did not carry challengeResult.finalScore into the MM score fallback path. When reviewSummation.aggregateScore and submission.finalScore were zero or -1 placeholders, the rerate could order the participant by the placeholder score.

What was changed
The MM rerate engine now joins challengeResult score data for both target history discovery and challenge participant loading. Positive challengeResult.finalScore is used only after positive aggregateScore and positive submission finalScore are unavailable, preserving existing MM aggregate and complete-placement behavior.

Any added/updated tests
Added a Marathon Match engine regression test for a Development-track Marathon Match where the summation score is a placeholder but challengeResult.finalScore is 100.
