### PR TITLE
PM-5221: include Data Science Challenge winners

### DIFF
--- a/src/services/StatisticsService.js
+++ b/src/services/StatisticsService.js
@@ -602,9 +602,10 @@ async function fetchMarathonMatchParticipantIds (reviewDbClient, challengeId) {
 
 /**
  * Resolve submitter ids for the challenge and rating source.
- * Marathon Match submitters are loaded from both challengeResult and final
- * review summations so partially synced result rows cannot omit lower-placed
- * participants from rerating.
+ * Challenge ratings include placement winners so completed challenges without
+ * challengeResult rows still rerate paid winners. Marathon Match submitters
+ * are loaded from both challengeResult and final review summations so partially
+ * synced result rows cannot omit lower-placed participants from rerating.
  * @param {Object} reviewDbClient raw pg review database client
  * @param {Object} challengeClient challenge Prisma client
  * @param {string|number} challengeId challenge identifier
@@ -613,7 +614,7 @@ async function fetchMarathonMatchParticipantIds (reviewDbClient, challengeId) {
  */
 async function fetchRatingParticipantIds (reviewDbClient, challengeClient, challengeId, source) {
   const challengeResultUserIds = await fetchChallengeResultParticipantIds(reviewDbClient, challengeId)
-  if (source === RATING_SOURCE_DEVELOPMENT) {
+  if (source === RATING_SOURCE_DEVELOPMENT || source === RATING_SOURCE_DATA_SCIENCE_CHALLENGE) {
     return _.uniqBy(
       challengeResultUserIds.concat(await fetchChallengeWinnerParticipantIds(challengeClient, challengeId)),
       stringifyUserId

--- a/test/unit/StatisticsService.test.js
+++ b/test/unit/StatisticsService.test.js
@@ -943,6 +943,76 @@ describe('statistics service unit tests', () => {
     }
   })
 
+  it('rerateChallengeSubmitterRatings should include Data Science Challenge winners when result rows are absent', async () => {
+    const dsRerateCalls = []
+    const { service, restore } = loadStatisticsService({
+      challengeRow: {
+        id: 'ds-winner-only-challenge',
+        status: 'COMPLETED',
+        endDate: new Date('2026-06-09T08:45:00.000Z'),
+        trackId: 'track-ds-id',
+        typeId: 'type-challenge-id',
+        track: { name: 'Data Science' },
+        type: { name: 'Challenge' },
+        tags: [],
+        skills: [],
+        metadata: []
+      },
+      reviewRows: [],
+      challengeWinnerRows: [
+        { challengeId: 'ds-winner-only-challenge', userId: 301, type: 'PLACEMENT', placement: 1 }
+      ],
+      prismaStub: {
+        member: {
+          findMany: async ({ where }) => where.userId.in.map((userId) => ({ userId }))
+        }
+      },
+      rerateDevTrack: async (membersClient, challengeClient, reviewDbClient, userId, challengeId, options) => {
+        dsRerateCalls.push({
+          userId: String(userId),
+          challengeId,
+          options
+        })
+        return {
+          challengesProcessed: 1,
+          ratingsUpdated: 1
+        }
+      }
+    })
+
+    try {
+      const result = await service.rerateChallengeSubmitterRatings({ isMachine: true }, {
+        challengeId: 'ds-winner-only-challenge'
+      })
+
+      result.rerated.should.equal(true)
+      result.membersProcessed.should.equal(1)
+      result.ratingsAttempted.should.equal(1)
+      result.ratingsUpdated.should.equal(1)
+      result.participantIds.should.deep.equal(['301'])
+      result.ratings.should.deep.equal([
+        {
+          trackId: 'DATA_SCIENCE',
+          typeId: 'Challenge'
+        }
+      ])
+      dsRerateCalls.should.deep.equal([
+        {
+          userId: '301',
+          challengeId: 'ds-winner-only-challenge',
+          options: {
+            targetTrackName: 'DATA_SCIENCE',
+            targetTypeName: 'Challenge',
+            challengeTrackNames: ['DATA_SCIENCE'],
+            challengeTypeNames: ['Challenge']
+          }
+        }
+      ])
+    } finally {
+      restore()
+    }
+  })
+
   it('rerateChallengeSubmitterRatings should include Marathon Match final summation submitters when result rows are partial', async () => {
     const mmRerateCalls = []
     const { service, restore } = loadStatisticsService({


### PR DESCRIPTION
What was broken
The completion rerate endpoint only added ChallengeWinner placement participants for Development Challenge ratings. A Data Science Challenge winner without a review-api challengeResult row was never passed to the rating replay, so no DATA_SCIENCE / Challenge rating or history row was created for that profile.

Root cause (if identifiable)
The previous PM-5221 fix added Data Science Challenge rating jobs and Data Science rating dimensions, but participant discovery for DATA_SCIENCE_CHALLENGE still returned only challengeResult submitters while DEVELOPMENT_CHALLENGE also appended ChallengeWinner placement ids.

What was changed
Data Science Challenge participant discovery now includes ChallengeWinner placement ids using the existing winner fallback and de-duplication path, matching the Development Challenge behavior.

Any added/updated tests
Added unit coverage for rerating Data Science Challenge winners when challengeResult rows are absent.
