### PR TITLE
PM-5223: route QA challenges into Data Science ratings

### DIFF
--- a/src/services/StatisticsService.js
+++ b/src/services/StatisticsService.js
@@ -69,6 +69,7 @@ const RATING_SOURCE_DEVELOPMENT = 'DEVELOPMENT_CHALLENGE'
 const RATING_SOURCE_DATA_SCIENCE_CHALLENGE = 'DATA_SCIENCE_CHALLENGE'
 const RATING_SOURCE_MARATHON_MATCH = 'MARATHON_MATCH'
 const RERATE_MARATHON_ACTOR = 'rerate-mm-stats'
+const CHALLENGE_TRACK_QUALITY_ASSURANCE = 'QUALITY_ASSURANCE'
 const CHALLENGE_WINNER_PLACEMENT_TYPE = 'PLACEMENT'
 const CHALLENGE_WINNER_PASSED_REVIEW_TYPE = 'PASSED_REVIEW'
 const CHALLENGE_WINNER_HISTORY_TYPES = [CHALLENGE_WINNER_PLACEMENT_TYPE, CHALLENGE_WINNER_PASSED_REVIEW_TYPE]
@@ -365,6 +366,38 @@ function isChallengeRatingEnabled (challenge) {
 }
 
 /**
+ * Normalize challenge track labels for source-routing checks.
+ * @param {*} value raw challenge track label, enum value, or abbreviation
+ * @returns {string} uppercase source track key
+ */
+function normalizeChallengeSourceTrack (value) {
+  return String(value || '')
+    .trim()
+    .toUpperCase()
+    .replace(/[\s-]+/g, '_')
+}
+
+/**
+ * Check whether a challenge source track is Quality Assurance.
+ * QA Challenge results are rated in the public Data Science Challenge bucket.
+ * @param {*} value raw challenge track label, enum value, or abbreviation
+ * @returns {boolean} true when the source track is QA
+ */
+function isQualityAssuranceChallengeSourceTrack (value) {
+  const normalizedTrack = normalizeChallengeSourceTrack(value)
+  return normalizedTrack === CHALLENGE_TRACK_QUALITY_ASSURANCE || normalizedTrack === 'QA'
+}
+
+/**
+ * Build the source tracks replayed for Data Science Challenge ratings.
+ * QA Challenges share the public Data Science Challenge rating bucket.
+ * @returns {Array<string>} challenge source track labels
+ */
+function getDataScienceChallengeSourceTrackNames () {
+  return [TRACK_NAMES.DATA_SCIENCE, CHALLENGE_TRACK_QUALITY_ASSURANCE]
+}
+
+/**
  * Load challenge metadata needed to decide which ratings apply.
  * @param {Object} challengeClient prisma challenge client
  * @param {string|number} challengeId challenge UUID or legacy numeric id
@@ -405,7 +438,8 @@ async function fetchChallengeForRatingUpdate (challengeClient, challengeId) {
       typeId: true,
       track: {
         select: {
-          name: true
+          name: true,
+          track: true
         }
       },
       type: {
@@ -432,14 +466,16 @@ async function fetchChallengeForRatingUpdate (challengeClient, challengeId) {
  * @returns {string|null} source identifier or null when unsupported
  */
 function resolveChallengeRatingSource (challenge) {
-  const trackName = getCanonicalTrackName(_.get(challenge, 'track.name') || _.get(challenge, 'trackId'))
+  const rawTrackName = _.get(challenge, 'track.track') || _.get(challenge, 'track.name') || _.get(challenge, 'trackId')
+  const trackName = getCanonicalTrackName(rawTrackName)
   const typeName = getCanonicalTypeName(_.get(challenge, 'type.name') || _.get(challenge, 'typeId'))
 
   if (trackName === TRACK_NAMES.DEVELOP && typeName === TYPE_NAMES.CHALLENGE) {
     return RATING_SOURCE_DEVELOPMENT
   }
 
-  if (trackName === TRACK_NAMES.DATA_SCIENCE && typeName === TYPE_NAMES.CHALLENGE) {
+  if ((trackName === TRACK_NAMES.DATA_SCIENCE || isQualityAssuranceChallengeSourceTrack(rawTrackName)) &&
+    typeName === TYPE_NAMES.CHALLENGE) {
     return RATING_SOURCE_DATA_SCIENCE_CHALLENGE
   }
 
@@ -554,7 +590,7 @@ async function fetchChallengeResultParticipantIds (reviewDbClient, challengeId) 
 
 /**
  * Fetch placement winner participants from challenge-api for completed
- * Development rating rerates. This covers QA-created challenges where winners
+ * Development/Data Science rating rerates. This covers challenges where winners
  * can be assigned without a review-api challengeResult row for the same member.
  * @param {Object} challengeClient challenge Prisma client
  * @param {string|number} challengeId challenge identifier
@@ -695,7 +731,7 @@ async function rerateChallengeRatingJobForMember (challengeClient, reviewDbClien
       ? {
         targetTrackName: TRACK_NAMES.DATA_SCIENCE,
         targetTypeName: TYPE_NAMES.CHALLENGE,
-        challengeTrackNames: [TRACK_NAMES.DATA_SCIENCE],
+        challengeTrackNames: getDataScienceChallengeSourceTrackNames(),
         challengeTypeNames: [TYPE_NAMES.CHALLENGE]
       }
       : undefined
@@ -4270,7 +4306,8 @@ refreshMemberStats.schema = {
  * Re-rate every existing submitter on a completed challenge for all applicable
  * rating dimensions. This includes the native challenge track/type rating when
  * supported and any configured named rating paths whose tags/skills match the
- * challenge, such as the default AI path.
+ * challenge, such as the default AI path. Quality Assurance Challenge rows are
+ * replayed into the public DATA_SCIENCE / Challenge rating bucket.
  * @param {Object} currentUser the user who performs operation
  * @param {Object} data rerate payload containing the completed challenge id
  * @returns {Object} summary of participants, rating jobs, updates, and per-member failures
@@ -4433,6 +4470,8 @@ rerateChallengeSubmitterRatings.schema = {
  * Trigger a DEVELOPMENT / Challenge, DATA_SCIENCE / Challenge,
  * DATA_SCIENCE / MARATHON_MATCH, or configured tag- or skill-based rating path
  * re-rating pass beginning with the supplied challenge.
+ * DATA_SCIENCE / Challenge rerates also replay Quality Assurance Challenge
+ * source rows because QA history is surfaced in that public rating bucket.
  * The relevant review-api results are reprocessed in chronological order and
  * persisted into the existing unified rating tables for the member.
  * @param {Object} currentUser the user who performs operation
@@ -4485,7 +4524,7 @@ async function rerateMemberStats (currentUser, handle, data) {
       {
         targetTrackName: TRACK_NAMES.DATA_SCIENCE,
         targetTypeName: TYPE_NAMES.CHALLENGE,
-        challengeTrackNames: [TRACK_NAMES.DATA_SCIENCE],
+        challengeTrackNames: getDataScienceChallengeSourceTrackNames(),
         challengeTypeNames: [TYPE_NAMES.CHALLENGE]
       }
     )

--- a/test/unit/DevelopRatingEngine.test.js
+++ b/test/unit/DevelopRatingEngine.test.js
@@ -598,6 +598,92 @@ describe('develop rating engine unit tests', () => {
     members.state.rankRecalculationCalls[0].typeId.should.equal(CHALLENGE_TYPE_ID)
   })
 
+  it('rerateDevTrack should include QA ChallengeWinner placements in Data Science Challenge rerates', async () => {
+    const targetUserId = toBigInt(89770374)
+    const opponentUserId = toBigInt(100000039)
+    const challengeId = 'qa-rating-jun-2'
+    const eventDate = new Date('2026-06-02T06:36:07.735Z')
+    const members = createMembersClient({
+      historyRows: [],
+      statsRows: [],
+      maxRatingRows: []
+    })
+    const reviewDbClient = createReviewDbClient([])
+    const challengeClient = createChallengeClient({
+      [challengeId]: {
+        id: challengeId,
+        status: 'COMPLETED',
+        endDate: eventDate,
+        track: { name: 'Quality Assurance' },
+        type: { name: 'Challenge' },
+        metadata: []
+      }
+    }, [
+      {
+        challengeId,
+        userId: Number(targetUserId),
+        type: 'PLACEMENT',
+        placement: 1,
+        createdAt: new Date('2026-06-02T06:37:00.000Z')
+      },
+      {
+        challengeId,
+        userId: Number(opponentUserId),
+        type: 'PLACEMENT',
+        placement: 2,
+        createdAt: new Date('2026-06-02T06:37:00.000Z')
+      }
+    ])
+    const expectedParticipants = [
+      createParticipant(targetUserId, 0, 0, 0, -1),
+      createParticipant(opponentUserId, 0, 0, 0, -2)
+    ]
+    runQubitsRating(expectedParticipants)
+    const expectedTarget = expectedParticipants.find((participant) => participant.coderId === String(targetUserId))
+
+    const result = await rerateDevTrack(
+      members.client,
+      challengeClient,
+      reviewDbClient,
+      targetUserId,
+      challengeId,
+      {
+        targetTrackName: 'DATA_SCIENCE',
+        targetTypeName: 'Challenge',
+        challengeTrackNames: ['DATA_SCIENCE', 'QUALITY_ASSURANCE'],
+        challengeTypeNames: ['Challenge']
+      }
+    )
+
+    result.challengesProcessed.should.equal(1)
+    result.ratingsUpdated.should.equal(1)
+
+    const statsRow = members.state.statsRows.find((row) =>
+      String(row.userId) === String(targetUserId) &&
+      row.trackId === DATA_SCIENCE_TRACK_ID &&
+      row.typeId === CHALLENGE_TYPE_ID
+    )
+    should.exist(statsRow)
+    statsRow.rating.should.equal(expectedTarget.rating)
+    statsRow.volatility.should.equal(expectedTarget.volatility)
+    statsRow.challenges.should.equal(1)
+    statsRow.mostRecentEventDate.should.deep.equal(eventDate)
+
+    const historyRow = findHistoryRow(members.state.historyRows, targetUserId, challengeId)
+    should.exist(historyRow)
+    historyRow.trackId.should.equal(DATA_SCIENCE_TRACK_ID)
+    historyRow.typeId.should.equal(CHALLENGE_TYPE_ID)
+    historyRow.newRating.should.equal(expectedTarget.rating)
+    historyRow.mostRecent.should.equal(true)
+
+    const maxRatingRow = members.state.maxRatingRows.find((row) => String(row.userId) === String(targetUserId))
+    should.exist(maxRatingRow)
+    maxRatingRow.rating.should.equal(expectedTarget.rating)
+    maxRatingRow.track.should.equal('DATA_SCIENCE')
+    maxRatingRow.subTrack.should.equal('Challenge')
+    maxRatingRow.ratingColor.should.equal(getRatingColor(expectedTarget.rating))
+  })
+
   it('rerateDevTrack should seed rerates from prior history instead of current snapshots', async () => {
     const targetUserId = toBigInt(1001)
     const opponentUserId = toBigInt(2002)

--- a/test/unit/StatisticsService.test.js
+++ b/test/unit/StatisticsService.test.js
@@ -923,7 +923,7 @@ describe('statistics service unit tests', () => {
           options: {
             targetTrackName: 'DATA_SCIENCE',
             targetTypeName: 'Challenge',
-            challengeTrackNames: ['DATA_SCIENCE'],
+            challengeTrackNames: ['DATA_SCIENCE', 'QUALITY_ASSURANCE'],
             challengeTypeNames: ['Challenge']
           }
         },
@@ -933,7 +933,7 @@ describe('statistics service unit tests', () => {
           options: {
             targetTrackName: 'DATA_SCIENCE',
             targetTypeName: 'Challenge',
-            challengeTrackNames: ['DATA_SCIENCE'],
+            challengeTrackNames: ['DATA_SCIENCE', 'QUALITY_ASSURANCE'],
             challengeTypeNames: ['Challenge']
           }
         }
@@ -1003,7 +1003,88 @@ describe('statistics service unit tests', () => {
           options: {
             targetTrackName: 'DATA_SCIENCE',
             targetTypeName: 'Challenge',
-            challengeTrackNames: ['DATA_SCIENCE'],
+            challengeTrackNames: ['DATA_SCIENCE', 'QUALITY_ASSURANCE'],
+            challengeTypeNames: ['Challenge']
+          }
+        }
+      ])
+    } finally {
+      restore()
+    }
+  })
+
+  it('rerateChallengeSubmitterRatings should rate QA Challenge winners in the Data Science Challenge bucket', async () => {
+    const qaRerateCalls = []
+    const { service, restore } = loadStatisticsService({
+      challengeRow: {
+        id: 'qa-winner-only-challenge',
+        status: 'COMPLETED',
+        endDate: new Date('2026-06-10T05:41:34.931Z'),
+        trackId: 'track-qa-id',
+        typeId: 'type-challenge-id',
+        track: { name: 'Quality Assurance', track: 'QUALITY_ASSURANCE' },
+        type: { name: 'Challenge' },
+        tags: [],
+        skills: [],
+        metadata: []
+      },
+      reviewRows: [],
+      challengeWinnerRows: [
+        { challengeId: 'qa-winner-only-challenge', userId: 89770374, type: 'PLACEMENT', placement: 1 },
+        { challengeId: 'qa-winner-only-challenge', userId: 100000039, type: 'PLACEMENT', placement: 2 }
+      ],
+      prismaStub: {
+        member: {
+          findMany: async ({ where }) => where.userId.in.map((userId) => ({ userId }))
+        }
+      },
+      rerateDevTrack: async (membersClient, challengeClient, reviewDbClient, userId, challengeId, options) => {
+        qaRerateCalls.push({
+          userId: String(userId),
+          challengeId,
+          options
+        })
+        return {
+          challengesProcessed: 1,
+          ratingsUpdated: 1
+        }
+      }
+    })
+
+    try {
+      const result = await service.rerateChallengeSubmitterRatings({ isMachine: true }, {
+        challengeId: 'qa-winner-only-challenge'
+      })
+
+      result.rerated.should.equal(true)
+      result.membersProcessed.should.equal(2)
+      result.ratingsAttempted.should.equal(2)
+      result.ratingsUpdated.should.equal(2)
+      result.participantIds.should.deep.equal(['89770374', '100000039'])
+      result.ratings.should.deep.equal([
+        {
+          trackId: 'DATA_SCIENCE',
+          typeId: 'Challenge'
+        }
+      ])
+      qaRerateCalls.should.deep.equal([
+        {
+          userId: '89770374',
+          challengeId: 'qa-winner-only-challenge',
+          options: {
+            targetTrackName: 'DATA_SCIENCE',
+            targetTypeName: 'Challenge',
+            challengeTrackNames: ['DATA_SCIENCE', 'QUALITY_ASSURANCE'],
+            challengeTypeNames: ['Challenge']
+          }
+        },
+        {
+          userId: '100000039',
+          challengeId: 'qa-winner-only-challenge',
+          options: {
+            targetTrackName: 'DATA_SCIENCE',
+            targetTypeName: 'Challenge',
+            challengeTrackNames: ['DATA_SCIENCE', 'QUALITY_ASSURANCE'],
             challengeTypeNames: ['Challenge']
           }
         }


### PR DESCRIPTION
What was broken
QA track Challenge completions were not added to member profile history and did not update ratings. The earlier PM-5223 fix added ChallengeWinner rows to rating replay, but only after the completed challenge had already been accepted as a supported Development or Data Science source.

Root cause (if identifiable)
Quality Assurance Challenge metadata resolves to a QUALITY_ASSURANCE source track, and the rerate dispatcher did not map that track to any supported rating source. Data Science Challenge replay also only admitted DATA_SCIENCE source challenges, so QA ChallengeWinner placements could not enter the target member timeline.

What was changed
Mapped Quality Assurance Challenge rows to the public DATA_SCIENCE / Challenge rating bucket. Data Science Challenge rerates now replay both DATA_SCIENCE and QUALITY_ASSURANCE source tracks, including ChallengeWinner placements when review-api result rows are missing.

Any added/updated tests
Added Development rating engine coverage for QA ChallengeWinner-only replay into DATA_SCIENCE / Challenge. Added StatisticsService coverage for rerating QA Challenge winners through the completed-challenge submitter rerate endpoint, and updated Data Science rerate expectations for the expanded source track list.

Focused tests and lint passed:

pnpm exec mocha -t 20000 test/unit/DevelopRatingEngine.test.js test/unit/StatisticsService.test.js --exit
pnpm lint

git diff --check passed.

Full pnpm test is blocked locally by missing PostgreSQL integration services at localhost:5432 after rerunning with the required database URLs. pnpm build is blocked because this package has no build script.
