### PR TITLE
PM-5223: show QA winner history under Data Science

### DIFF
--- a/src/services/StatisticsService.js
+++ b/src/services/StatisticsService.js
@@ -963,8 +963,8 @@ function isMarathonMatchType (typeName) {
 
 /**
  * Resolve the public stats dimensions for a challenge-backed row.
- * Marathon Match is part of the public DATA_SCIENCE bucket even when imported
- * challenge metadata has a Development track.
+ * Marathon Match and QA Challenge rows are part of the public DATA_SCIENCE
+ * bucket even when source challenge metadata uses a different track.
  * @param {Object} row row containing trackId and typeId
  * @param {Object} dimensionLookup shared challenge dimension lookup
  * @returns {Object} normalized track/type ids and names
@@ -981,10 +981,21 @@ function resolveStatsDimensionForChallengeRow (row, dimensionLookup) {
     }
   }
 
+  const trackName = resolveTrackNameFromLookup(dimensionLookup, row.trackId)
+  if (typeName === TYPE_NAMES.CHALLENGE && isQualityAssuranceChallengeSourceTrack(trackName)) {
+    const dataScienceTrackId = resolveTrackIdFromLookup(dimensionLookup, TRACK_NAMES.DATA_SCIENCE)
+    return {
+      trackId: dataScienceTrackId || row.trackId,
+      typeId: row.typeId,
+      trackName: TRACK_NAMES.DATA_SCIENCE,
+      typeName
+    }
+  }
+
   return {
     trackId: row.trackId,
     typeId: row.typeId,
-    trackName: resolveTrackNameFromLookup(dimensionLookup, row.trackId),
+    trackName,
     typeName
   }
 }

--- a/test/unit/StatisticsService.test.js
+++ b/test/unit/StatisticsService.test.js
@@ -71,7 +71,8 @@ function createStatsDimensionHelperStub () {
   const trackNamesById = {
     'track-dev-id': TRACK_NAMES.DEVELOP,
     'track-design-id': TRACK_NAMES.DESIGN,
-    'track-ds-id': TRACK_NAMES.DATA_SCIENCE
+    'track-ds-id': TRACK_NAMES.DATA_SCIENCE,
+    'track-qa-id': 'Quality Assurance'
   }
   const typeNamesById = {
     'type-challenge-id': TYPE_NAMES.CHALLENGE,
@@ -1979,6 +1980,58 @@ describe('statistics service unit tests', () => {
       result[0].DEVELOP.subTracks[0].history[0].challengeName.should.equal('Winner fallback challenge')
       result[0].DEVELOP.subTracks[0].history[0].placement.should.equal(1)
       result[0].DEVELOP.subTracks[0].history[0].mostRecent.should.equal(true)
+    } finally {
+      restore()
+    }
+  })
+
+  it('getHistoryStats should surface QA challenge winner history under Data Science Challenge', async () => {
+    const ratingDate = new Date('2026-06-15T08:00:00.000Z')
+    const qaChallenge = {
+      id: 'qa-challenge-june-15',
+      name: 'QA Challenge June 15',
+      status: 'COMPLETED',
+      trackId: 'track-qa-id',
+      typeId: 'type-challenge-id',
+      endDate: ratingDate
+    }
+    const { service, restore } = loadStatisticsService({
+      prismaStub: {
+        $queryRaw: async () => [],
+        memberStats: {
+          findFirst: async () => null,
+          findMany: async () => [{
+            trackId: 'track-ds-id',
+            typeId: 'type-challenge-id'
+          }]
+        },
+        memberStatsHistory: {
+          findMany: async () => []
+        }
+      },
+      challengeRows: [],
+      reviewRows: [],
+      challengeWinnerRows: [{
+        challengeId: 'qa-challenge-june-15',
+        type: 'PLACEMENT',
+        placement: 1,
+        createdAt: new Date('2026-06-15T08:01:00.000Z'),
+        challenge: qaChallenge
+      }]
+    })
+
+    try {
+      const result = await service.getHistoryStats({ isMachine: true }, 'devtest1400', {})
+
+      result.should.have.length(1)
+      should.exist(result[0].DATA_SCIENCE)
+      should.exist(result[0].DATA_SCIENCE.Challenge)
+      result[0].DATA_SCIENCE.Challenge.history.should.have.length(1)
+      result[0].DATA_SCIENCE.Challenge.history[0].challengeId.should.equal('qa-challenge-june-15')
+      result[0].DATA_SCIENCE.Challenge.history[0].challengeName.should.equal('QA Challenge June 15')
+      result[0].DATA_SCIENCE.Challenge.history[0].placement.should.equal(1)
+      result[0].DATA_SCIENCE.Challenge.history[0].ratingDate.should.equal(ratingDate.getTime())
+      result[0].DATA_SCIENCE.Challenge.history[0].mostRecent.should.equal(true)
     } finally {
       restore()
     }


### PR DESCRIPTION
What was broken
QA Challenge winners could rerate into the public Data Science Challenge bucket and update the member's main rating, but winner-only QA challenge cards could still be absent from profile stats history when no persisted history row was available.

Root cause (if identifiable)
The previous fix mapped QA Challenge rows for rating replay, but the stats history fallback still resolved challenge-backed history rows from the source challenge track. QA source rows therefore resolved to a Quality Assurance track, which is not one of the public history groups exposed by member-api.

What was changed
Normalized QA Challenge source rows to the public DATA_SCIENCE / Challenge dimension in the shared stats dimension resolver used by review-result and ChallengeWinner history fallbacks.

Any added/updated tests
Added StatisticsService coverage showing a winner-only QA Challenge is returned under DATA_SCIENCE.Challenge history when the member has the Data Science Challenge aggregate but no persisted history row.

Focused validation passed:

pnpm exec mocha -t 20000 test/unit/DevelopRatingEngine.test.js test/unit/StatisticsService.test.js --exit
pnpm lint
git diff --check

Full pnpm test remains blocked by local integration prerequisites outside this ticket. With no DB env it fails before running because RESOURCES_DB_URL is unset. With placeholder service URLs it reaches 141 passing tests and then fails because PostgreSQL is unavailable. With a temporary member PostgreSQL schema it progresses further but still needs standardized-skills tables and Auth0/bus test setup. pnpm build is blocked because this package has no build script.
