### PR TITLE
PM-5223: route QA challenge stats to Testing

### DIFF
--- a/src/common/statsDimensionHelper.js
+++ b/src/common/statsDimensionHelper.js
@@ -10,6 +10,9 @@ const TRACK_NAMES = {
 const TYPE_NAMES = {
   CHALLENGE: 'Challenge',
   CODE: 'CODE',
+  BUG_HUNT: 'BUG_HUNT',
+  TEST_SCENARIOS: 'TEST_SCENARIOS',
+  TEST_SUITES: 'TEST_SUITES',
   FIRST2FINISH: 'First2Finish',
   TASK: 'Task',
   SRM: 'SRM',
@@ -175,6 +178,9 @@ function buildChallengeDimensionLookup (trackRows, typeRows) {
   lookup.typeIds = {
     CHALLENGE: resolveTypeIdFromLookup(lookup, TYPE_NAMES.CHALLENGE) || null,
     CODE: resolveTypeIdFromLookup(lookup, TYPE_NAMES.CODE) || null,
+    BUG_HUNT: resolveTypeIdFromLookup(lookup, TYPE_NAMES.BUG_HUNT) || null,
+    TEST_SCENARIOS: resolveTypeIdFromLookup(lookup, TYPE_NAMES.TEST_SCENARIOS) || null,
+    TEST_SUITES: resolveTypeIdFromLookup(lookup, TYPE_NAMES.TEST_SUITES) || null,
     FIRST2FINISH: resolveTypeIdFromLookup(lookup, TYPE_NAMES.FIRST2FINISH) || null,
     TASK: resolveTypeIdFromLookup(lookup, TYPE_NAMES.TASK) || null,
     SRM: resolveTypeIdFromLookup(lookup, TYPE_NAMES.SRM) || null,

--- a/src/scripts/recalculateMemberStats.js
+++ b/src/scripts/recalculateMemberStats.js
@@ -365,7 +365,8 @@ function isMarathonMatchTypeId (typeId) {
 /**
  * Normalize challenge metadata dimensions into the public stats dimensions.
  * Marathon Match stats/history belong to DATA_SCIENCE even when the source
- * challenge row was imported with a Development track.
+ * challenge row was imported with a Development track. QA Challenge rows belong
+ * to the legacy Testing surface under DEVELOP / BUG_HUNT.
  * @param {*} trackId raw ChallengeTrack id
  * @param {*} typeId raw ChallengeType id
  * @returns {Object} normalized trackId/typeId pair
@@ -376,6 +377,20 @@ function normalizeChallengeStatsDimension (trackId, typeId) {
     return {
       trackId: legacyLookupCache.trackIds.DATA_SCIENCE,
       typeId: normalizedTypeId
+    }
+  }
+
+  const trackName = resolveTrackNameFromLookup(legacyLookupCache, trackId)
+  const typeName = resolveTypeNameFromLookup(legacyLookupCache, normalizedTypeId) || resolveTypeName(normalizedTypeId)
+  const normalizedTrackName = normalizeLookupKey(trackName).replace(/[\s-]+/g, '_')
+  if (legacyLookupCache &&
+    (normalizedTrackName === 'QUALITY_ASSURANCE' || normalizedTrackName === 'QA') &&
+    typeName === TYPE_NAMES.CHALLENGE &&
+    legacyLookupCache.trackIds.DEVELOP &&
+    legacyLookupCache.typeIds.BUG_HUNT) {
+    return {
+      trackId: legacyLookupCache.trackIds.DEVELOP,
+      typeId: legacyLookupCache.typeIds.BUG_HUNT
     }
   }
 

--- a/src/services/StatisticsService.js
+++ b/src/services/StatisticsService.js
@@ -67,6 +67,7 @@ if (!_.includes(SUPPORTED_STATS_READ_SOURCES, configuredStatsReadSource)) {
 const USE_LEGACY_STATS_READS = configuredStatsReadSource === LEGACY_STATS_READ_SOURCE
 const RATING_SOURCE_DEVELOPMENT = 'DEVELOPMENT_CHALLENGE'
 const RATING_SOURCE_DATA_SCIENCE_CHALLENGE = 'DATA_SCIENCE_CHALLENGE'
+const RATING_SOURCE_QUALITY_ASSURANCE_CHALLENGE = 'QUALITY_ASSURANCE_CHALLENGE'
 const RATING_SOURCE_MARATHON_MATCH = 'MARATHON_MATCH'
 const RERATE_MARATHON_ACTOR = 'rerate-mm-stats'
 const CHALLENGE_TRACK_QUALITY_ASSURANCE = 'QUALITY_ASSURANCE'
@@ -379,7 +380,7 @@ function normalizeChallengeSourceTrack (value) {
 
 /**
  * Check whether a challenge source track is Quality Assurance.
- * QA Challenge results are rated in the public Data Science Challenge bucket.
+ * QA Challenge results are surfaced in the legacy Testing bucket.
  * @param {*} value raw challenge track label, enum value, or abbreviation
  * @returns {boolean} true when the source track is QA
  */
@@ -390,11 +391,18 @@ function isQualityAssuranceChallengeSourceTrack (value) {
 
 /**
  * Build the source tracks replayed for Data Science Challenge ratings.
- * QA Challenges share the public Data Science Challenge rating bucket.
  * @returns {Array<string>} challenge source track labels
  */
 function getDataScienceChallengeSourceTrackNames () {
-  return [TRACK_NAMES.DATA_SCIENCE, CHALLENGE_TRACK_QUALITY_ASSURANCE]
+  return [TRACK_NAMES.DATA_SCIENCE]
+}
+
+/**
+ * Build the source tracks replayed for Quality Assurance Challenge ratings.
+ * @returns {Array<string>} challenge source track labels
+ */
+function getQualityAssuranceChallengeSourceTrackNames () {
+  return [CHALLENGE_TRACK_QUALITY_ASSURANCE]
 }
 
 /**
@@ -474,8 +482,11 @@ function resolveChallengeRatingSource (challenge) {
     return RATING_SOURCE_DEVELOPMENT
   }
 
-  if ((trackName === TRACK_NAMES.DATA_SCIENCE || isQualityAssuranceChallengeSourceTrack(rawTrackName)) &&
-    typeName === TYPE_NAMES.CHALLENGE) {
+  if (isQualityAssuranceChallengeSourceTrack(rawTrackName) && typeName === TYPE_NAMES.CHALLENGE) {
+    return RATING_SOURCE_QUALITY_ASSURANCE_CHALLENGE
+  }
+
+  if (trackName === TRACK_NAMES.DATA_SCIENCE && typeName === TYPE_NAMES.CHALLENGE) {
     return RATING_SOURCE_DATA_SCIENCE_CHALLENGE
   }
 
@@ -510,6 +521,14 @@ function buildBaseRatingJob (challenge, source) {
       source,
       trackId: TRACK_NAMES.DATA_SCIENCE,
       typeId: TYPE_NAMES.CHALLENGE
+    }
+  }
+
+  if (source === RATING_SOURCE_QUALITY_ASSURANCE_CHALLENGE) {
+    return {
+      source,
+      trackId: TRACK_NAMES.DEVELOP,
+      typeId: TYPE_NAMES.BUG_HUNT
     }
   }
 
@@ -650,7 +669,9 @@ async function fetchMarathonMatchParticipantIds (reviewDbClient, challengeId) {
  */
 async function fetchRatingParticipantIds (reviewDbClient, challengeClient, challengeId, source) {
   const challengeResultUserIds = await fetchChallengeResultParticipantIds(reviewDbClient, challengeId)
-  if (source === RATING_SOURCE_DEVELOPMENT || source === RATING_SOURCE_DATA_SCIENCE_CHALLENGE) {
+  if (source === RATING_SOURCE_DEVELOPMENT ||
+    source === RATING_SOURCE_DATA_SCIENCE_CHALLENGE ||
+    source === RATING_SOURCE_QUALITY_ASSURANCE_CHALLENGE) {
     return _.uniqBy(
       challengeResultUserIds.concat(await fetchChallengeWinnerParticipantIds(challengeClient, challengeId)),
       stringifyUserId
@@ -726,15 +747,24 @@ async function rerateChallengeRatingJobForMember (challengeClient, reviewDbClien
   }
 
   if (job.source === RATING_SOURCE_DEVELOPMENT ||
-    job.source === RATING_SOURCE_DATA_SCIENCE_CHALLENGE) {
-    const rerateOptions = job.source === RATING_SOURCE_DATA_SCIENCE_CHALLENGE
-      ? {
+    job.source === RATING_SOURCE_DATA_SCIENCE_CHALLENGE ||
+    job.source === RATING_SOURCE_QUALITY_ASSURANCE_CHALLENGE) {
+    let rerateOptions
+    if (job.source === RATING_SOURCE_DATA_SCIENCE_CHALLENGE) {
+      rerateOptions = {
         targetTrackName: TRACK_NAMES.DATA_SCIENCE,
         targetTypeName: TYPE_NAMES.CHALLENGE,
         challengeTrackNames: getDataScienceChallengeSourceTrackNames(),
         challengeTypeNames: [TYPE_NAMES.CHALLENGE]
       }
-      : undefined
+    } else if (job.source === RATING_SOURCE_QUALITY_ASSURANCE_CHALLENGE) {
+      rerateOptions = {
+        targetTrackName: TRACK_NAMES.DEVELOP,
+        targetTypeName: TYPE_NAMES.BUG_HUNT,
+        challengeTrackNames: getQualityAssuranceChallengeSourceTrackNames(),
+        challengeTypeNames: [TYPE_NAMES.CHALLENGE]
+      }
+    }
 
     return rerateDevTrack(
       prisma,
@@ -963,8 +993,9 @@ function isMarathonMatchType (typeName) {
 
 /**
  * Resolve the public stats dimensions for a challenge-backed row.
- * Marathon Match and QA Challenge rows are part of the public DATA_SCIENCE
- * bucket even when source challenge metadata uses a different track.
+ * Marathon Match rows are part of the public DATA_SCIENCE bucket even when
+ * source challenge metadata uses a different track. QA Challenge rows retain
+ * the legacy Testing surface under DEVELOP / BUG_HUNT.
  * @param {Object} row row containing trackId and typeId
  * @param {Object} dimensionLookup shared challenge dimension lookup
  * @returns {Object} normalized track/type ids and names
@@ -983,12 +1014,16 @@ function resolveStatsDimensionForChallengeRow (row, dimensionLookup) {
 
   const trackName = resolveTrackNameFromLookup(dimensionLookup, row.trackId)
   if (typeName === TYPE_NAMES.CHALLENGE && isQualityAssuranceChallengeSourceTrack(trackName)) {
-    const dataScienceTrackId = resolveTrackIdFromLookup(dimensionLookup, TRACK_NAMES.DATA_SCIENCE)
-    return {
-      trackId: dataScienceTrackId || row.trackId,
-      typeId: row.typeId,
-      trackName: TRACK_NAMES.DATA_SCIENCE,
-      typeName
+    const developTrackId = resolveTrackIdFromLookup(dimensionLookup, TRACK_NAMES.DEVELOP)
+    const bugHuntTypeId = resolveTypeIdFromLookup(dimensionLookup, TYPE_NAMES.BUG_HUNT)
+
+    if (developTrackId && bugHuntTypeId) {
+      return {
+        trackId: developTrackId,
+        typeId: bugHuntTypeId,
+        trackName: TRACK_NAMES.DEVELOP,
+        typeName: TYPE_NAMES.BUG_HUNT
+      }
     }
   }
 
@@ -1236,9 +1271,10 @@ function filterUnifiedHistoryRowsToCompletedChallenges (rows, challengeMetadataB
  * the response payload consumed by the profiles UI.
  * @param {Array<Object>} rows unified history rows loaded from members.memberStatsHistory
  * @param {Map<string, Object>} challengeMetadataById challenge metadata keyed by UUID and legacy ids
+ * @param {Object} dimensionLookup shared challenge dimension lookup
  * @returns {Array<Object>} rows enriched with canonical challenge ids and names when available
  */
-function enrichUnifiedHistoryRowsWithChallengeMetadata (rows, challengeMetadataById) {
+function enrichUnifiedHistoryRowsWithChallengeMetadata (rows, challengeMetadataById, dimensionLookup) {
   return _.map(rows || [], (row) => {
     const challengeId = _.isNil(row.challengeId) ? null : String(row.challengeId).trim()
     if (!challengeId) {
@@ -1257,9 +1293,16 @@ function enrichUnifiedHistoryRowsWithChallengeMetadata (rows, challengeMetadataB
         : _.get(challenge, 'legacyRecord.legacySystemId')
     )
     const preserveLegacyChallengeId = isLegacyNumericMarathonHistoryRow(row)
+    const dimension = challenge.trackId && challenge.typeId
+      ? resolveStatsDimensionForChallengeRow({
+        trackId: String(challenge.trackId),
+        typeId: String(challenge.typeId)
+      }, dimensionLookup)
+      : {}
 
     return {
       ...row,
+      ...dimension,
       challengeId: preserveLegacyChallengeId ? challengeId : canonicalChallengeId,
       canonicalChallengeId,
       legacyChallengeId,
@@ -1532,10 +1575,7 @@ function buildAggregatedStatsFromReviewResults (reviewRows, challengeMetadataByI
       return
     }
 
-    const dimension = resolveStatsDimensionForChallengeRow({
-      trackId: String(challenge.trackId),
-      typeId: String(challenge.typeId)
-    }, dimensionLookup)
+    const dimension = resolveStatsDimensionForChallengeRow(challenge, dimensionLookup)
     const trackId = dimension.trackId
     const typeId = dimension.typeId
     if (!trackId || !typeId) {
@@ -1647,10 +1687,7 @@ function buildFallbackHistoryRowsFromReviewResults (reviewRows, challengeMetadat
       return
     }
 
-    const dimension = resolveStatsDimensionForChallengeRow({
-      trackId: String(challenge.trackId),
-      typeId: String(challenge.typeId)
-    }, dimensionLookup)
+    const dimension = resolveStatsDimensionForChallengeRow(challenge, dimensionLookup)
     const trackId = dimension.trackId
     const typeId = dimension.typeId
     const pairKey = buildStatsTrackTypeKey(trackId, typeId)
@@ -1731,10 +1768,7 @@ function buildFallbackHistoryRowsFromChallengeWinners (winnerRows, dimensionLook
       return
     }
 
-    const dimension = resolveStatsDimensionForChallengeRow({
-      trackId: String(challenge.trackId),
-      typeId: String(challenge.typeId)
-    }, dimensionLookup)
+    const dimension = resolveStatsDimensionForChallengeRow(challenge, dimensionLookup)
     const trackId = dimension.trackId
     const typeId = dimension.typeId
     const pairKey = buildStatsTrackTypeKey(trackId, typeId)
@@ -3425,7 +3459,8 @@ async function getHistoryStats (currentUser, handle, query) {
       let annotatedRows = dedupeUnifiedHistoryRows(filterUnifiedHistoryRowsToCompletedChallenges(
         enrichUnifiedHistoryRowsWithChallengeMetadata(
           annotateUnifiedDimensionRows(historyRows, dimensionLookup),
-          challengeMetadataById
+          challengeMetadataById,
+          dimensionLookup
         ),
         challengeMetadataById
       ))
@@ -4318,7 +4353,7 @@ refreshMemberStats.schema = {
  * rating dimensions. This includes the native challenge track/type rating when
  * supported and any configured named rating paths whose tags/skills match the
  * challenge, such as the default AI path. Quality Assurance Challenge rows are
- * replayed into the public DATA_SCIENCE / Challenge rating bucket.
+ * replayed into the legacy Testing bucket under DEVELOP / BUG_HUNT.
  * @param {Object} currentUser the user who performs operation
  * @param {Object} data rerate payload containing the completed challenge id
  * @returns {Object} summary of participants, rating jobs, updates, and per-member failures
@@ -4481,8 +4516,6 @@ rerateChallengeSubmitterRatings.schema = {
  * Trigger a DEVELOPMENT / Challenge, DATA_SCIENCE / Challenge,
  * DATA_SCIENCE / MARATHON_MATCH, or configured tag- or skill-based rating path
  * re-rating pass beginning with the supplied challenge.
- * DATA_SCIENCE / Challenge rerates also replay Quality Assurance Challenge
- * source rows because QA history is surfaced in that public rating bucket.
  * The relevant review-api results are reprocessed in chronological order and
  * persisted into the existing unified rating tables for the member.
  * @param {Object} currentUser the user who performs operation

--- a/test/unit/DevelopRatingEngine.test.js
+++ b/test/unit/DevelopRatingEngine.test.js
@@ -19,6 +19,7 @@ const DEVELOP_TRACK_ID = 'track-develop-id'
 const DATA_SCIENCE_TRACK_ID = 'track-data-science-id'
 const CHALLENGE_TYPE_ID = 'type-challenge-id'
 const CODE_TYPE_ID = 'type-code-id'
+const BUG_HUNT_TYPE_ID = 'type-bug-hunt-id'
 const MARATHON_MATCH_TYPE_ID = 'type-marathon-match-id'
 
 function isBigIntValue (value) {
@@ -371,6 +372,7 @@ function createChallengeClient (metadataById, winnerRows = []) {
         return [
           { id: CHALLENGE_TYPE_ID, name: 'Challenge', abbreviation: 'CH', legacyId: null, isTask: false },
           { id: CODE_TYPE_ID, name: 'Code', abbreviation: 'CODE', legacyId: null, isTask: false },
+          { id: BUG_HUNT_TYPE_ID, name: 'BUG_HUNT', abbreviation: 'LBGH', legacyId: 120, isTask: false },
           { id: MARATHON_MATCH_TYPE_ID, name: 'Marathon Match', abbreviation: 'MM', legacyId: null, isTask: false }
         ]
       }
@@ -598,7 +600,7 @@ describe('develop rating engine unit tests', () => {
     members.state.rankRecalculationCalls[0].typeId.should.equal(CHALLENGE_TYPE_ID)
   })
 
-  it('rerateDevTrack should include QA ChallengeWinner placements in Data Science Challenge rerates', async () => {
+  it('rerateDevTrack should include QA ChallengeWinner placements in Testing rerates', async () => {
     const targetUserId = toBigInt(89770374)
     const opponentUserId = toBigInt(100000039)
     const challengeId = 'qa-rating-jun-2'
@@ -648,9 +650,9 @@ describe('develop rating engine unit tests', () => {
       targetUserId,
       challengeId,
       {
-        targetTrackName: 'DATA_SCIENCE',
-        targetTypeName: 'Challenge',
-        challengeTrackNames: ['DATA_SCIENCE', 'QUALITY_ASSURANCE'],
+        targetTrackName: 'DEVELOP',
+        targetTypeName: 'BUG_HUNT',
+        challengeTrackNames: ['QUALITY_ASSURANCE'],
         challengeTypeNames: ['Challenge']
       }
     )
@@ -660,8 +662,8 @@ describe('develop rating engine unit tests', () => {
 
     const statsRow = members.state.statsRows.find((row) =>
       String(row.userId) === String(targetUserId) &&
-      row.trackId === DATA_SCIENCE_TRACK_ID &&
-      row.typeId === CHALLENGE_TYPE_ID
+      row.trackId === DEVELOP_TRACK_ID &&
+      row.typeId === BUG_HUNT_TYPE_ID
     )
     should.exist(statsRow)
     statsRow.rating.should.equal(expectedTarget.rating)
@@ -671,16 +673,16 @@ describe('develop rating engine unit tests', () => {
 
     const historyRow = findHistoryRow(members.state.historyRows, targetUserId, challengeId)
     should.exist(historyRow)
-    historyRow.trackId.should.equal(DATA_SCIENCE_TRACK_ID)
-    historyRow.typeId.should.equal(CHALLENGE_TYPE_ID)
+    historyRow.trackId.should.equal(DEVELOP_TRACK_ID)
+    historyRow.typeId.should.equal(BUG_HUNT_TYPE_ID)
     historyRow.newRating.should.equal(expectedTarget.rating)
     historyRow.mostRecent.should.equal(true)
 
     const maxRatingRow = members.state.maxRatingRows.find((row) => String(row.userId) === String(targetUserId))
     should.exist(maxRatingRow)
     maxRatingRow.rating.should.equal(expectedTarget.rating)
-    maxRatingRow.track.should.equal('DATA_SCIENCE')
-    maxRatingRow.subTrack.should.equal('Challenge')
+    maxRatingRow.track.should.equal('DEVELOP')
+    maxRatingRow.subTrack.should.equal('BUG_HUNT')
     maxRatingRow.ratingColor.should.equal(getRatingColor(expectedTarget.rating))
   })
 

--- a/test/unit/RecalculateMemberStats.test.js
+++ b/test/unit/RecalculateMemberStats.test.js
@@ -19,13 +19,15 @@ describe('recalculateMemberStats unit tests', () => {
           return [
             { id: 'track-dev-id', name: 'Development', abbreviation: 'DEV', legacyId: null },
             { id: 'track-design-id', name: 'Design', abbreviation: 'DES', legacyId: null },
-            { id: 'track-ds-id', name: 'Data Science', abbreviation: 'DS', legacyId: null }
+            { id: 'track-ds-id', name: 'Data Science', abbreviation: 'DS', legacyId: null },
+            { id: 'track-qa-id', name: 'Quality Assurance', abbreviation: 'QA', legacyId: null }
           ]
         }
 
         if (query.includes('"ChallengeType"')) {
           return [
             { id: 'type-ch-id', name: 'Challenge', abbreviation: 'CH', legacyId: null, isTask: false },
+            { id: 'type-bug-hunt-id', name: 'BUG_HUNT', abbreviation: 'LBGH', legacyId: 120, isTask: false },
             { id: 'type-f2f-id', name: 'First2Finish', abbreviation: 'F2F', legacyId: null, isTask: false },
             { id: 'type-mm-id', name: 'Marathon Match', abbreviation: 'MM', legacyId: null, isTask: false }
           ]
@@ -41,6 +43,64 @@ describe('recalculateMemberStats unit tests', () => {
     recalculateMemberStats.resolveLegacyDesignTypeId('STUDIO_OTHER', 34).should.equal('type-ch-id')
     recalculateMemberStats.resolveLegacyDesignTypeId('DESIGN_FIRST_2_FINISH', 40).should.equal('type-f2f-id')
     recalculateMemberStats.resolveLegacyDesignTypeId(null, 40).should.equal('type-f2f-id')
+  })
+
+  it('should normalize QA challenge aggregates into the Testing bucket', async () => {
+    const fakeChallengesClient = {
+      $queryRaw (strings) {
+        const query = strings.join('')
+        if (query.includes('"ChallengeTrack"')) {
+          return [
+            { id: 'track-dev-id', name: 'Development', abbreviation: 'DEV', legacyId: null },
+            { id: 'track-design-id', name: 'Design', abbreviation: 'DES', legacyId: null },
+            { id: 'track-ds-id', name: 'Data Science', abbreviation: 'DS', legacyId: null },
+            { id: 'track-qa-id', name: 'Quality Assurance', abbreviation: 'QA', legacyId: null }
+          ]
+        }
+
+        if (query.includes('"ChallengeType"')) {
+          return [
+            { id: 'type-ch-id', name: 'Challenge', abbreviation: 'CH', legacyId: null, isTask: false },
+            { id: 'type-bug-hunt-id', name: 'BUG_HUNT', abbreviation: 'LBGH', legacyId: 120, isTask: false },
+            { id: 'type-mm-id', name: 'Marathon Match', abbreviation: 'MM', legacyId: null, isTask: false }
+          ]
+        }
+
+        throw new Error(`Unexpected query: ${query}`)
+      }
+    }
+
+    await recalculateMemberStats.initializeLegacyLookupCache(fakeChallengesClient)
+
+    const eventDate = new Date('2026-06-15T08:00:00.000Z')
+    const results = recalculateMemberStats.buildAggregatedStatsFromReviewResults(
+      [{
+        challengeId: 'qa-challenge-june-15',
+        userId: global.BigInt(88770025),
+        submissionId: 'submission-1',
+        validSubmission: true,
+        placement: 1,
+        createdAt: new Date('2026-06-15T08:01:00.000Z')
+      }],
+      new Map([[
+        'qa-challenge-june-15',
+        {
+          id: 'qa-challenge-june-15',
+          trackId: 'track-qa-id',
+          typeId: 'type-ch-id',
+          status: 'COMPLETED',
+          endDate: eventDate
+        }
+      ]]),
+      {}
+    )
+
+    results.should.have.length(1)
+    results[0].trackId.should.equal('track-dev-id')
+    results[0].typeId.should.equal('type-bug-hunt-id')
+    results[0].challenges.should.equal(1)
+    results[0].wins.should.equal(1)
+    results[0].mostRecentEventDate.should.deep.equal(eventDate)
   })
 
   it('should parse the concurrency option', () => {

--- a/test/unit/StatisticsService.test.js
+++ b/test/unit/StatisticsService.test.js
@@ -48,6 +48,9 @@ function createStatsDimensionHelperStub () {
   const TYPE_NAMES = {
     CHALLENGE: 'Challenge',
     CODE: 'CODE',
+    BUG_HUNT: 'BUG_HUNT',
+    TEST_SCENARIOS: 'TEST_SCENARIOS',
+    TEST_SUITES: 'TEST_SUITES',
     FIRST2FINISH: 'First2Finish',
     TASK: 'Task',
     SRM: 'SRM',
@@ -62,6 +65,9 @@ function createStatsDimensionHelperStub () {
   const typeIds = {
     CHALLENGE: 'type-challenge-id',
     CODE: 'type-code-id',
+    BUG_HUNT: 'type-bug-hunt-id',
+    TEST_SCENARIOS: 'type-test-scenarios-id',
+    TEST_SUITES: 'type-test-suites-id',
     FIRST2FINISH: 'type-f2f-id',
     TASK: 'type-task-id',
     SRM: 'type-srm-id',
@@ -77,6 +83,9 @@ function createStatsDimensionHelperStub () {
   const typeNamesById = {
     'type-challenge-id': TYPE_NAMES.CHALLENGE,
     'type-code-id': TYPE_NAMES.CODE,
+    'type-bug-hunt-id': TYPE_NAMES.BUG_HUNT,
+    'type-test-scenarios-id': TYPE_NAMES.TEST_SCENARIOS,
+    'type-test-suites-id': TYPE_NAMES.TEST_SUITES,
     'type-f2f-id': TYPE_NAMES.FIRST2FINISH,
     'type-task-id': TYPE_NAMES.TASK,
     'type-srm-id': TYPE_NAMES.SRM,
@@ -113,6 +122,15 @@ function createStatsDimensionHelperStub () {
     }
     if (normalized === 'CODE' || normalized === 'COD') {
       return typeIds.CODE
+    }
+    if (normalized === 'BUG_HUNT' || normalized === 'LBGH') {
+      return typeIds.BUG_HUNT
+    }
+    if (normalized === 'TEST_SCENARIOS' || normalized === 'LSCN') {
+      return typeIds.TEST_SCENARIOS
+    }
+    if (normalized === 'TEST_SUITES' || normalized === 'LTST') {
+      return typeIds.TEST_SUITES
     }
     if (normalized === 'TASK' || normalized === 'TSK') {
       return typeIds.TASK
@@ -153,6 +171,15 @@ function createStatsDimensionHelperStub () {
       }
       if (normalized === 'CODE' || normalized === 'COD') {
         return TYPE_NAMES.CODE
+      }
+      if (normalized === 'BUG_HUNT' || normalized === 'LBGH') {
+        return TYPE_NAMES.BUG_HUNT
+      }
+      if (normalized === 'TEST_SCENARIOS' || normalized === 'LSCN') {
+        return TYPE_NAMES.TEST_SCENARIOS
+      }
+      if (normalized === 'TEST_SUITES' || normalized === 'LTST') {
+        return TYPE_NAMES.TEST_SUITES
       }
       if (normalized === 'TASK' || normalized === 'TSK') {
         return TYPE_NAMES.TASK
@@ -924,7 +951,7 @@ describe('statistics service unit tests', () => {
           options: {
             targetTrackName: 'DATA_SCIENCE',
             targetTypeName: 'Challenge',
-            challengeTrackNames: ['DATA_SCIENCE', 'QUALITY_ASSURANCE'],
+            challengeTrackNames: ['DATA_SCIENCE'],
             challengeTypeNames: ['Challenge']
           }
         },
@@ -934,7 +961,7 @@ describe('statistics service unit tests', () => {
           options: {
             targetTrackName: 'DATA_SCIENCE',
             targetTypeName: 'Challenge',
-            challengeTrackNames: ['DATA_SCIENCE', 'QUALITY_ASSURANCE'],
+            challengeTrackNames: ['DATA_SCIENCE'],
             challengeTypeNames: ['Challenge']
           }
         }
@@ -1004,7 +1031,7 @@ describe('statistics service unit tests', () => {
           options: {
             targetTrackName: 'DATA_SCIENCE',
             targetTypeName: 'Challenge',
-            challengeTrackNames: ['DATA_SCIENCE', 'QUALITY_ASSURANCE'],
+            challengeTrackNames: ['DATA_SCIENCE'],
             challengeTypeNames: ['Challenge']
           }
         }
@@ -1014,7 +1041,7 @@ describe('statistics service unit tests', () => {
     }
   })
 
-  it('rerateChallengeSubmitterRatings should rate QA Challenge winners in the Data Science Challenge bucket', async () => {
+  it('rerateChallengeSubmitterRatings should rate QA Challenge winners in the Testing bucket', async () => {
     const qaRerateCalls = []
     const { service, restore } = loadStatisticsService({
       challengeRow: {
@@ -1064,8 +1091,8 @@ describe('statistics service unit tests', () => {
       result.participantIds.should.deep.equal(['89770374', '100000039'])
       result.ratings.should.deep.equal([
         {
-          trackId: 'DATA_SCIENCE',
-          typeId: 'Challenge'
+          trackId: 'DEVELOP',
+          typeId: 'BUG_HUNT'
         }
       ])
       qaRerateCalls.should.deep.equal([
@@ -1073,9 +1100,9 @@ describe('statistics service unit tests', () => {
           userId: '89770374',
           challengeId: 'qa-winner-only-challenge',
           options: {
-            targetTrackName: 'DATA_SCIENCE',
-            targetTypeName: 'Challenge',
-            challengeTrackNames: ['DATA_SCIENCE', 'QUALITY_ASSURANCE'],
+            targetTrackName: 'DEVELOP',
+            targetTypeName: 'BUG_HUNT',
+            challengeTrackNames: ['QUALITY_ASSURANCE'],
             challengeTypeNames: ['Challenge']
           }
         },
@@ -1083,9 +1110,9 @@ describe('statistics service unit tests', () => {
           userId: '100000039',
           challengeId: 'qa-winner-only-challenge',
           options: {
-            targetTrackName: 'DATA_SCIENCE',
-            targetTypeName: 'Challenge',
-            challengeTrackNames: ['DATA_SCIENCE', 'QUALITY_ASSURANCE'],
+            targetTrackName: 'DEVELOP',
+            targetTypeName: 'BUG_HUNT',
+            challengeTrackNames: ['QUALITY_ASSURANCE'],
             challengeTypeNames: ['Challenge']
           }
         }
@@ -1985,7 +2012,7 @@ describe('statistics service unit tests', () => {
     }
   })
 
-  it('getHistoryStats should surface QA challenge winner history under Data Science Challenge', async () => {
+  it('getHistoryStats should surface QA challenge winner history under Testing', async () => {
     const ratingDate = new Date('2026-06-15T08:00:00.000Z')
     const qaChallenge = {
       id: 'qa-challenge-june-15',
@@ -2001,8 +2028,8 @@ describe('statistics service unit tests', () => {
         memberStats: {
           findFirst: async () => null,
           findMany: async () => [{
-            trackId: 'track-ds-id',
-            typeId: 'type-challenge-id'
+            trackId: 'track-dev-id',
+            typeId: 'type-bug-hunt-id'
           }]
         },
         memberStatsHistory: {
@@ -2024,14 +2051,72 @@ describe('statistics service unit tests', () => {
       const result = await service.getHistoryStats({ isMachine: true }, 'devtest1400', {})
 
       result.should.have.length(1)
-      should.exist(result[0].DATA_SCIENCE)
-      should.exist(result[0].DATA_SCIENCE.Challenge)
-      result[0].DATA_SCIENCE.Challenge.history.should.have.length(1)
-      result[0].DATA_SCIENCE.Challenge.history[0].challengeId.should.equal('qa-challenge-june-15')
-      result[0].DATA_SCIENCE.Challenge.history[0].challengeName.should.equal('QA Challenge June 15')
-      result[0].DATA_SCIENCE.Challenge.history[0].placement.should.equal(1)
-      result[0].DATA_SCIENCE.Challenge.history[0].ratingDate.should.equal(ratingDate.getTime())
-      result[0].DATA_SCIENCE.Challenge.history[0].mostRecent.should.equal(true)
+      should.exist(result[0].DEVELOP)
+      result[0].DEVELOP.subTracks.should.have.length(1)
+      result[0].DEVELOP.subTracks[0].name.should.equal('BUG_HUNT')
+      result[0].DEVELOP.subTracks[0].history.should.have.length(1)
+      result[0].DEVELOP.subTracks[0].history[0].challengeId.should.equal('qa-challenge-june-15')
+      result[0].DEVELOP.subTracks[0].history[0].challengeName.should.equal('QA Challenge June 15')
+      result[0].DEVELOP.subTracks[0].history[0].placement.should.equal(1)
+      result[0].DEVELOP.subTracks[0].history[0].ratingDate.should.equal(ratingDate.getTime())
+      result[0].DEVELOP.subTracks[0].history[0].mostRecent.should.equal(true)
+    } finally {
+      restore()
+    }
+  })
+
+  it('getHistoryStats should remap persisted QA challenge history from Data Science to Testing', async () => {
+    const ratingDate = new Date('2026-06-15T08:00:00.000Z')
+    const qaChallenge = {
+      id: 'qa-challenge-june-15',
+      legacyId: null,
+      name: 'QA Challenge June 15',
+      status: 'COMPLETED',
+      trackId: 'track-qa-id',
+      typeId: 'type-challenge-id',
+      endDate: ratingDate
+    }
+    const { service, restore } = loadStatisticsService({
+      prismaStub: {
+        $queryRaw: async () => [],
+        memberStats: {
+          findFirst: async () => null,
+          findMany: async () => [{
+            trackId: 'track-ds-id',
+            typeId: 'type-challenge-id'
+          }]
+        },
+        memberStatsHistory: {
+          findMany: async () => [{
+            trackId: 'track-ds-id',
+            typeId: 'type-challenge-id',
+            challengeId: 'qa-challenge-june-15',
+            challengeName: null,
+            eventDate: ratingDate,
+            ratingDate,
+            newRating: 1400,
+            placement: 1,
+            mostRecent: true
+          }]
+        }
+      },
+      challengeRows: [qaChallenge]
+    })
+
+    try {
+      const result = await service.getHistoryStats({ isMachine: true }, 'devtest1400', {})
+
+      result.should.have.length(1)
+      should.exist(result[0].DEVELOP)
+      should.not.exist(result[0].DATA_SCIENCE)
+      result[0].DEVELOP.subTracks.should.have.length(1)
+      result[0].DEVELOP.subTracks[0].name.should.equal('BUG_HUNT')
+      result[0].DEVELOP.subTracks[0].history.should.have.length(1)
+      result[0].DEVELOP.subTracks[0].history[0].challengeId.should.equal('qa-challenge-june-15')
+      result[0].DEVELOP.subTracks[0].history[0].challengeName.should.equal('QA Challenge June 15')
+      result[0].DEVELOP.subTracks[0].history[0].rating.should.equal(1400)
+      result[0].DEVELOP.subTracks[0].history[0].placement.should.equal(1)
+      result[0].DEVELOP.subTracks[0].history[0].ratingDate.should.equal(ratingDate.getTime())
     } finally {
       restore()
     }


### PR DESCRIPTION
What was broken
QA Challenge rows were being replayed and displayed under DATA_SCIENCE / Challenge, so profile history showed QA wins in the Data Science Challenge section instead of the Testing section.

Root cause (if identifiable)
The previous follow-up normalized Quality Assurance Challenge rows into the Data Science Challenge bucket for both rerating and history fallback. That made the rating update visible, but it used the wrong public profile bucket for QA challenges.

What was changed
Routed Quality Assurance Challenge rerates to DEVELOP / BUG_HUNT, the legacy testing subtrack used by the profiles app for Testing. Data Science Challenge rerates now replay only Data Science source challenges.

History reads also remap persisted QA Challenge rows out of DATA_SCIENCE / Challenge and into DEVELOP / BUG_HUNT when challenge metadata identifies the source as Quality Assurance. The member stats recalculation helper applies the same QA dimension normalization for future backfills.

Any added/updated tests
Updated Development rating engine and StatisticsService coverage for QA Challenge winners under Testing.

Added StatisticsService coverage for remapping previously persisted Data Science QA history rows into Testing.

Added recalculation coverage for QA aggregate normalization into the Testing bucket.

Validation
Focused unit tests passed: pnpm exec mocha -t 20000 test/unit/DevelopRatingEngine.test.js test/unit/StatisticsService.test.js test/unit/RecalculateMemberStats.test.js --exit

Lint passed: pnpm lint

git diff --check passed.

Full pnpm test is blocked locally by integration prerequisites outside this ticket. Without DB env it fails before running because RESOURCES_DB_URL is unset. With placeholder DB URLs it reaches 143 passing tests, then fails because PostgreSQL is unavailable at localhost:5432 for MemberService and MemberTraitService integration setup.

pnpm build is blocked because this package has no build script.
