### PR TITLE
PM-5223: route QA challenge ratings to QA

### DIFF
--- a/src/common/prismaHelper.js
+++ b/src/common/prismaHelper.js
@@ -49,6 +49,10 @@ const marathonRankFields = [
   'minimumRating', 'maximumRating', 'countryRank', 'schoolRank', 'defaultLanguage'
 ]
 
+const groupedSubTrackStatsTrackNames = ['DEVELOP', 'DESIGN', 'QA']
+const supportedUnifiedStatsTrackNames = ['DEVELOP', 'DESIGN', 'DATA_SCIENCE', 'QA', 'COPILOT']
+const supportedUnifiedHistoryTrackNames = ['DEVELOP', 'DESIGN', 'DATA_SCIENCE', 'QA']
+
 const auditFields = [
   'createdAt', 'createdBy', 'updatedAt', 'updatedBy'
 ]
@@ -331,8 +335,10 @@ function applyMaxRatingRankFallback (item) {
     return
   }
 
-  if (trackName === 'DEVELOP' && item.DEVELOP && _.isArray(item.DEVELOP.subTracks)) {
-    const statsItem = _.find(item.DEVELOP.subTracks, subTrack =>
+  if ((trackName === 'DEVELOP' || trackName === 'QA') &&
+    item[trackName] &&
+    _.isArray(item[trackName].subTracks)) {
+    const statsItem = _.find(item[trackName].subTracks, subTrack =>
       getUnifiedTypeName(subTrack.id || subTrack.name) === typeName
     )
     if (statsItem) {
@@ -616,7 +622,7 @@ function buildUnifiedStatsResponse (member, statsData, fields) {
       resolvedTrackName: getUnifiedTrackName(row.trackName || row.trackId),
       resolvedTypeName: getUnifiedTypeName(row.typeName || row.typeId)
     }))
-    .filter(row => _.includes(['DEVELOP', 'DESIGN', 'DATA_SCIENCE', 'COPILOT'], row.resolvedTrackName))
+    .filter(row => _.includes(supportedUnifiedStatsTrackNames, row.resolvedTrackName))
     .value()
   const first = _.head(validRows) || {}
   const item = {
@@ -635,10 +641,10 @@ function buildUnifiedStatsResponse (member, statsData, fields) {
   _.forEach(validRows, (row) => {
     const trackName = row.resolvedTrackName
     const typeName = row.resolvedTypeName
-    if (trackName === 'DEVELOP') {
+    if (trackName === 'DEVELOP' || trackName === 'QA') {
       const challengeCount = toNumber(row.challenges)
-      if (!item.DEVELOP) {
-        item.DEVELOP = {
+      if (!item[trackName]) {
+        item[trackName] = {
           challenges: 0,
           wins: 0,
           mostRecentSubmission: null,
@@ -646,7 +652,7 @@ function buildUnifiedStatsResponse (member, statsData, fields) {
           subTracks: []
         }
       }
-      mergeTrackCounters(item.DEVELOP, row)
+      mergeTrackCounters(item[trackName], row)
       const subTrackItem = {
         id: typeName,
         name: typeName,
@@ -683,7 +689,7 @@ function buildUnifiedStatsResponse (member, statsData, fields) {
         rank.minRating = row.minRating
       }
       subTrackItem.rank = rank
-      item.DEVELOP.subTracks.push(subTrackItem)
+      item[trackName].subTracks.push(subTrackItem)
     } else if (trackName === 'DESIGN') {
       if (!item.DESIGN) {
         item.DESIGN = {
@@ -806,7 +812,7 @@ function buildUnifiedStatsHistoryResponse (member, historyStats, fields) {
       resolvedTrackName: getUnifiedTrackName(row.trackName || row.trackId),
       resolvedTypeName: getUnifiedTypeName(row.typeName || row.typeId)
     }))
-    .filter(row => _.includes(['DEVELOP', 'DESIGN', 'DATA_SCIENCE'], row.resolvedTrackName))
+    .filter(row => _.includes(supportedUnifiedHistoryTrackNames, row.resolvedTrackName))
     .value()
   const first = _.head(validRows) || {}
   const item = {
@@ -819,8 +825,8 @@ function buildUnifiedStatsHistoryResponse (member, historyStats, fields) {
   const groupedByTrackType = _.groupBy(validRows, row => `${row.resolvedTrackName}::${row.resolvedTypeName}`)
   _.forEach(groupedByTrackType, (trackHistory, key) => {
     const [trackName, typeName] = key.split('::')
-    if (trackName === 'DEVELOP' || trackName === 'DESIGN') {
-      const historyTrackName = trackName === 'DESIGN' ? 'DESIGN' : 'DEVELOP'
+    if (_.includes(groupedSubTrackStatsTrackNames, trackName)) {
+      const historyTrackName = trackName
       if (!item[historyTrackName]) {
         item[historyTrackName] = { subTracks: [] }
       }

--- a/src/common/statsDimensionHelper.js
+++ b/src/common/statsDimensionHelper.js
@@ -4,6 +4,7 @@ const TRACK_NAMES = {
   DEVELOP: 'DEVELOP',
   DESIGN: 'DESIGN',
   DATA_SCIENCE: 'DATA_SCIENCE',
+  QA: 'QA',
   COPILOT: 'COPILOT'
 }
 
@@ -49,6 +50,10 @@ function getCanonicalTrackName (value) {
 
   if (normalized.includes('DATA') && normalized.includes('SCIENCE')) {
     return TRACK_NAMES.DATA_SCIENCE
+  }
+
+  if (normalized === 'QA' || (normalized.includes('QUALITY') && normalized.includes('ASSURANCE'))) {
+    return TRACK_NAMES.QA
   }
 
   if (normalized.includes('DEVELOP') || normalized === 'DEV') {
@@ -143,6 +148,9 @@ function buildChallengeDimensionLookup (trackRows, typeRows) {
     addLookupEntry(trackIdsByLookup, row.abbreviation, id)
     addLookupEntry(trackIdsByLookup, row.legacyId, id)
     addLookupEntry(trackIdsByLookup, canonicalTrackName, id)
+    if (canonicalTrackName === TRACK_NAMES.QA) {
+      addLookupEntry(trackIdsByLookup, 'QUALITY_ASSURANCE', id)
+    }
   })
 
   typeRows.forEach((row) => {
@@ -173,6 +181,7 @@ function buildChallengeDimensionLookup (trackRows, typeRows) {
     DEVELOP: resolveTrackIdFromLookup(lookup, TRACK_NAMES.DEVELOP) || null,
     DESIGN: resolveTrackIdFromLookup(lookup, TRACK_NAMES.DESIGN) || null,
     DATA_SCIENCE: resolveTrackIdFromLookup(lookup, TRACK_NAMES.DATA_SCIENCE) || null,
+    QA: resolveTrackIdFromLookup(lookup, TRACK_NAMES.QA) || null,
     COPILOT: resolveTrackIdFromLookup(lookup, TRACK_NAMES.COPILOT) || null
   }
   lookup.typeIds = {

--- a/src/scripts/recalculateMemberStats.js
+++ b/src/scripts/recalculateMemberStats.js
@@ -366,7 +366,7 @@ function isMarathonMatchTypeId (typeId) {
  * Normalize challenge metadata dimensions into the public stats dimensions.
  * Marathon Match stats/history belong to DATA_SCIENCE even when the source
  * challenge row was imported with a Development track. QA Challenge rows belong
- * to the legacy Testing surface under DEVELOP / BUG_HUNT.
+ * to the first-class QA / Challenge dimension.
  * @param {*} trackId raw ChallengeTrack id
  * @param {*} typeId raw ChallengeType id
  * @returns {Object} normalized trackId/typeId pair
@@ -386,11 +386,11 @@ function normalizeChallengeStatsDimension (trackId, typeId) {
   if (legacyLookupCache &&
     (normalizedTrackName === 'QUALITY_ASSURANCE' || normalizedTrackName === 'QA') &&
     typeName === TYPE_NAMES.CHALLENGE &&
-    legacyLookupCache.trackIds.DEVELOP &&
-    legacyLookupCache.typeIds.BUG_HUNT) {
+    legacyLookupCache.trackIds.QA &&
+    legacyLookupCache.typeIds.CHALLENGE) {
     return {
-      trackId: legacyLookupCache.trackIds.DEVELOP,
-      typeId: legacyLookupCache.typeIds.BUG_HUNT
+      trackId: legacyLookupCache.trackIds.QA,
+      typeId: legacyLookupCache.typeIds.CHALLENGE
     }
   }
 

--- a/src/services/SearchService.js
+++ b/src/services/SearchService.js
@@ -49,7 +49,7 @@ const MEMBER_AUTOCOMPLETE_FIELDS = ['userId', 'handle', 'handleLower',
 
 var MEMBER_STATS_FIELDS = ['userId', 'handle', 'handleLower', 'maxRating',
   'numberOfChallengesWon', 'numberOfChallengesPlaced',
-  'challenges', 'wins', 'DEVELOP', 'DESIGN', 'DATA_SCIENCE', 'COPILOT']
+  'challenges', 'wins', 'DEVELOP', 'DESIGN', 'DATA_SCIENCE', 'QA', 'COPILOT']
 
 const SKILL_LEVEL_WEIGHTS = {
   verified: 1.0,

--- a/src/services/StatisticsService.js
+++ b/src/services/StatisticsService.js
@@ -48,11 +48,11 @@ const DISTRIBUTION_FIELDS = ['track', 'subTrack', 'distribution', 'createdAt', '
   'createdBy', 'updatedBy']
 const DISTRIBUTION_FIELDS_NO_DATE = ['track', 'subTrack', 'distribution']
 
-const HISTORY_STATS_FIELDS = ['userId', 'groupId', 'handle', 'handleLower', 'DEVELOP', 'DESIGN', 'DATA_SCIENCE',
+const HISTORY_STATS_FIELDS = ['userId', 'groupId', 'handle', 'handleLower', 'DEVELOP', 'DESIGN', 'DATA_SCIENCE', 'QA',
   'createdAt', 'updatedAt', 'createdBy', 'updatedBy']
 
 const MEMBER_STATS_FIELDS = ['userId', 'groupId', 'handle', 'handleLower', 'maxRating',
-  'challenges', 'wins', 'DEVELOP', 'DESIGN', 'DATA_SCIENCE', 'COPILOT', 'createdAt',
+  'challenges', 'wins', 'DEVELOP', 'DESIGN', 'DATA_SCIENCE', 'QA', 'COPILOT', 'createdAt',
   'updatedAt', 'createdBy', 'updatedBy']
 
 const LEGACY_STATS_READ_SOURCE = 'legacy'
@@ -380,7 +380,6 @@ function normalizeChallengeSourceTrack (value) {
 
 /**
  * Check whether a challenge source track is Quality Assurance.
- * QA Challenge results are surfaced in the legacy Testing bucket.
  * @param {*} value raw challenge track label, enum value, or abbreviation
  * @returns {boolean} true when the source track is QA
  */
@@ -527,8 +526,8 @@ function buildBaseRatingJob (challenge, source) {
   if (source === RATING_SOURCE_QUALITY_ASSURANCE_CHALLENGE) {
     return {
       source,
-      trackId: TRACK_NAMES.DEVELOP,
-      typeId: TYPE_NAMES.BUG_HUNT
+      trackId: TRACK_NAMES.QA,
+      typeId: TYPE_NAMES.CHALLENGE
     }
   }
 
@@ -609,7 +608,7 @@ async function fetchChallengeResultParticipantIds (reviewDbClient, challengeId) 
 
 /**
  * Fetch placement winner participants from challenge-api for completed
- * Development/Data Science rating rerates. This covers challenges where winners
+ * Development/Data Science/QA rating rerates. This covers challenges where winners
  * can be assigned without a review-api challengeResult row for the same member.
  * @param {Object} challengeClient challenge Prisma client
  * @param {string|number} challengeId challenge identifier
@@ -759,8 +758,8 @@ async function rerateChallengeRatingJobForMember (challengeClient, reviewDbClien
       }
     } else if (job.source === RATING_SOURCE_QUALITY_ASSURANCE_CHALLENGE) {
       rerateOptions = {
-        targetTrackName: TRACK_NAMES.DEVELOP,
-        targetTypeName: TYPE_NAMES.BUG_HUNT,
+        targetTrackName: TRACK_NAMES.QA,
+        targetTypeName: TYPE_NAMES.CHALLENGE,
         challengeTrackNames: getQualityAssuranceChallengeSourceTrackNames(),
         challengeTypeNames: [TYPE_NAMES.CHALLENGE]
       }
@@ -994,8 +993,8 @@ function isMarathonMatchType (typeName) {
 /**
  * Resolve the public stats dimensions for a challenge-backed row.
  * Marathon Match rows are part of the public DATA_SCIENCE bucket even when
- * source challenge metadata uses a different track. QA Challenge rows retain
- * the legacy Testing surface under DEVELOP / BUG_HUNT.
+ * source challenge metadata uses a different track. QA Challenge rows remain
+ * under the first-class QA / Challenge dimension.
  * @param {Object} row row containing trackId and typeId
  * @param {Object} dimensionLookup shared challenge dimension lookup
  * @returns {Object} normalized track/type ids and names
@@ -1014,15 +1013,15 @@ function resolveStatsDimensionForChallengeRow (row, dimensionLookup) {
 
   const trackName = resolveTrackNameFromLookup(dimensionLookup, row.trackId)
   if (typeName === TYPE_NAMES.CHALLENGE && isQualityAssuranceChallengeSourceTrack(trackName)) {
-    const developTrackId = resolveTrackIdFromLookup(dimensionLookup, TRACK_NAMES.DEVELOP)
-    const bugHuntTypeId = resolveTypeIdFromLookup(dimensionLookup, TYPE_NAMES.BUG_HUNT)
+    const qaTrackId = resolveTrackIdFromLookup(dimensionLookup, TRACK_NAMES.QA)
+    const challengeTypeId = resolveTypeIdFromLookup(dimensionLookup, TYPE_NAMES.CHALLENGE)
 
-    if (developTrackId && bugHuntTypeId) {
+    if (qaTrackId && challengeTypeId) {
       return {
-        trackId: developTrackId,
-        typeId: bugHuntTypeId,
-        trackName: TRACK_NAMES.DEVELOP,
-        typeName: TYPE_NAMES.BUG_HUNT
+        trackId: qaTrackId,
+        typeId: challengeTypeId,
+        trackName: TRACK_NAMES.QA,
+        typeName: TYPE_NAMES.CHALLENGE
       }
     }
   }
@@ -1618,12 +1617,12 @@ function buildAggregatedStatsFromReviewResults (reviewRows, challengeMetadataByI
 
 /**
  * Check whether the unified history response should surface the supplied track.
- * The public history contract currently exposes DEVELOPMENT, DESIGN, and DATA_SCIENCE groups.
+ * The public history contract currently exposes DEVELOPMENT, DESIGN, DATA_SCIENCE, and QA groups.
  * @param {string|undefined} trackName canonical track label
  * @returns {boolean} true when the track should be included in history responses
  */
 function isSupportedUnifiedHistoryTrack (trackName) {
-  return _.includes([TRACK_NAMES.DEVELOP, TRACK_NAMES.DESIGN, TRACK_NAMES.DATA_SCIENCE], trackName)
+  return _.includes([TRACK_NAMES.DEVELOP, TRACK_NAMES.DESIGN, TRACK_NAMES.DATA_SCIENCE, TRACK_NAMES.QA], trackName)
 }
 
 /**
@@ -4353,7 +4352,7 @@ refreshMemberStats.schema = {
  * rating dimensions. This includes the native challenge track/type rating when
  * supported and any configured named rating paths whose tags/skills match the
  * challenge, such as the default AI path. Quality Assurance Challenge rows are
- * replayed into the legacy Testing bucket under DEVELOP / BUG_HUNT.
+ * replayed into the first-class QA / Challenge stats dimension.
  * @param {Object} currentUser the user who performs operation
  * @param {Object} data rerate payload containing the completed challenge id
  * @returns {Object} summary of participants, rating jobs, updates, and per-member failures
@@ -4514,7 +4513,7 @@ rerateChallengeSubmitterRatings.schema = {
 
 /**
  * Trigger a DEVELOPMENT / Challenge, DATA_SCIENCE / Challenge,
- * DATA_SCIENCE / MARATHON_MATCH, or configured tag- or skill-based rating path
+ * QA / Challenge, DATA_SCIENCE / MARATHON_MATCH, or configured tag- or skill-based rating path
  * re-rating pass beginning with the supplied challenge.
  * The relevant review-api results are reprocessed in chronological order and
  * persisted into the existing unified rating tables for the member.
@@ -4572,6 +4571,20 @@ async function rerateMemberStats (currentUser, handle, data) {
         challengeTypeNames: [TYPE_NAMES.CHALLENGE]
       }
     )
+  } else if (trackId === TRACK_NAMES.QA && typeId === TYPE_NAMES.CHALLENGE) {
+    result = await rerateDevTrack(
+      prisma,
+      challengeClient,
+      reviewDbClient,
+      member.userId,
+      payload.challengeId,
+      {
+        targetTrackName: TRACK_NAMES.QA,
+        targetTypeName: TYPE_NAMES.CHALLENGE,
+        challengeTrackNames: getQualityAssuranceChallengeSourceTrackNames(),
+        challengeTypeNames: [TYPE_NAMES.CHALLENGE]
+      }
+    )
   } else if (trackId === TRACK_NAMES.DATA_SCIENCE && typeId === TYPE_NAMES.MARATHON_MATCH) {
     result = await rerateMmTrack(
       prisma,
@@ -4582,7 +4595,7 @@ async function rerateMemberStats (currentUser, handle, data) {
       payload.challengeId
     )
   } else {
-    throw new errors.BadRequestError('Only DEVELOP / Challenge, DATA_SCIENCE / Challenge, and DATA_SCIENCE / MARATHON_MATCH rerates are currently supported.')
+    throw new errors.BadRequestError('Only DEVELOP / Challenge, DATA_SCIENCE / Challenge, QA / Challenge, and DATA_SCIENCE / MARATHON_MATCH rerates are currently supported.')
   }
 
   return {
@@ -4607,7 +4620,7 @@ rerateMemberStats.schema = {
   data: Joi.object().keys({
     challengeId: Joi.alternatives().try(Joi.string().uuid(), Joi.number().integer().strict()).required(),
     ratingName: Joi.string(),
-    trackId: Joi.string().valid(TRACK_NAMES.DEVELOP, TRACK_NAMES.DATA_SCIENCE).insensitive(),
+    trackId: Joi.string().valid(TRACK_NAMES.DEVELOP, TRACK_NAMES.DATA_SCIENCE, TRACK_NAMES.QA).insensitive(),
     typeId: Joi.string().valid(TYPE_NAMES.CHALLENGE, TYPE_NAMES.MARATHON_MATCH).insensitive()
   }).required()
 }

--- a/test/unit/DevelopRatingEngine.test.js
+++ b/test/unit/DevelopRatingEngine.test.js
@@ -17,6 +17,7 @@ const {
 const should = chai.should()
 const DEVELOP_TRACK_ID = 'track-develop-id'
 const DATA_SCIENCE_TRACK_ID = 'track-data-science-id'
+const QA_TRACK_ID = 'track-qa-id'
 const CHALLENGE_TYPE_ID = 'type-challenge-id'
 const CODE_TYPE_ID = 'type-code-id'
 const BUG_HUNT_TYPE_ID = 'type-bug-hunt-id'
@@ -364,7 +365,8 @@ function createChallengeClient (metadataById, winnerRows = []) {
       if (sql.includes('FROM "ChallengeTrack"')) {
         return [
           { id: DEVELOP_TRACK_ID, name: 'Development', abbreviation: 'DEV', legacyId: null },
-          { id: DATA_SCIENCE_TRACK_ID, name: 'Data Science', abbreviation: 'DS', legacyId: null }
+          { id: DATA_SCIENCE_TRACK_ID, name: 'Data Science', abbreviation: 'DS', legacyId: null },
+          { id: QA_TRACK_ID, name: 'Quality Assurance', abbreviation: 'QA', legacyId: null }
         ]
       }
 
@@ -600,7 +602,7 @@ describe('develop rating engine unit tests', () => {
     members.state.rankRecalculationCalls[0].typeId.should.equal(CHALLENGE_TYPE_ID)
   })
 
-  it('rerateDevTrack should include QA ChallengeWinner placements in Testing rerates', async () => {
+  it('rerateDevTrack should include QA ChallengeWinner placements in QA rerates', async () => {
     const targetUserId = toBigInt(89770374)
     const opponentUserId = toBigInt(100000039)
     const challengeId = 'qa-rating-jun-2'
@@ -650,8 +652,8 @@ describe('develop rating engine unit tests', () => {
       targetUserId,
       challengeId,
       {
-        targetTrackName: 'DEVELOP',
-        targetTypeName: 'BUG_HUNT',
+        targetTrackName: 'QA',
+        targetTypeName: 'Challenge',
         challengeTrackNames: ['QUALITY_ASSURANCE'],
         challengeTypeNames: ['Challenge']
       }
@@ -662,8 +664,8 @@ describe('develop rating engine unit tests', () => {
 
     const statsRow = members.state.statsRows.find((row) =>
       String(row.userId) === String(targetUserId) &&
-      row.trackId === DEVELOP_TRACK_ID &&
-      row.typeId === BUG_HUNT_TYPE_ID
+      row.trackId === QA_TRACK_ID &&
+      row.typeId === CHALLENGE_TYPE_ID
     )
     should.exist(statsRow)
     statsRow.rating.should.equal(expectedTarget.rating)
@@ -673,16 +675,16 @@ describe('develop rating engine unit tests', () => {
 
     const historyRow = findHistoryRow(members.state.historyRows, targetUserId, challengeId)
     should.exist(historyRow)
-    historyRow.trackId.should.equal(DEVELOP_TRACK_ID)
-    historyRow.typeId.should.equal(BUG_HUNT_TYPE_ID)
+    historyRow.trackId.should.equal(QA_TRACK_ID)
+    historyRow.typeId.should.equal(CHALLENGE_TYPE_ID)
     historyRow.newRating.should.equal(expectedTarget.rating)
     historyRow.mostRecent.should.equal(true)
 
     const maxRatingRow = members.state.maxRatingRows.find((row) => String(row.userId) === String(targetUserId))
     should.exist(maxRatingRow)
     maxRatingRow.rating.should.equal(expectedTarget.rating)
-    maxRatingRow.track.should.equal('DEVELOP')
-    maxRatingRow.subTrack.should.equal('BUG_HUNT')
+    maxRatingRow.track.should.equal('QA')
+    maxRatingRow.subTrack.should.equal('Challenge')
     maxRatingRow.ratingColor.should.equal(getRatingColor(expectedTarget.rating))
   })
 

--- a/test/unit/RecalculateMemberStats.test.js
+++ b/test/unit/RecalculateMemberStats.test.js
@@ -45,7 +45,7 @@ describe('recalculateMemberStats unit tests', () => {
     recalculateMemberStats.resolveLegacyDesignTypeId(null, 40).should.equal('type-f2f-id')
   })
 
-  it('should normalize QA challenge aggregates into the Testing bucket', async () => {
+  it('should normalize QA challenge aggregates into the QA bucket', async () => {
     const fakeChallengesClient = {
       $queryRaw (strings) {
         const query = strings.join('')
@@ -96,8 +96,8 @@ describe('recalculateMemberStats unit tests', () => {
     )
 
     results.should.have.length(1)
-    results[0].trackId.should.equal('track-dev-id')
-    results[0].typeId.should.equal('type-bug-hunt-id')
+    results[0].trackId.should.equal('track-qa-id')
+    results[0].typeId.should.equal('type-ch-id')
     results[0].challenges.should.equal(1)
     results[0].wins.should.equal(1)
     results[0].mostRecentEventDate.should.deep.equal(eventDate)

--- a/test/unit/StatisticsService.test.js
+++ b/test/unit/StatisticsService.test.js
@@ -43,7 +43,8 @@ function createStatsDimensionHelperStub () {
   const TRACK_NAMES = {
     DEVELOP: 'DEVELOP',
     DESIGN: 'DESIGN',
-    DATA_SCIENCE: 'DATA_SCIENCE'
+    DATA_SCIENCE: 'DATA_SCIENCE',
+    QA: 'QA'
   }
   const TYPE_NAMES = {
     CHALLENGE: 'Challenge',
@@ -60,7 +61,8 @@ function createStatsDimensionHelperStub () {
   const trackIds = {
     DEVELOP: 'track-dev-id',
     DESIGN: 'track-design-id',
-    DATA_SCIENCE: 'track-ds-id'
+    DATA_SCIENCE: 'track-ds-id',
+    QA: 'track-qa-id'
   }
   const typeIds = {
     CHALLENGE: 'type-challenge-id',
@@ -78,7 +80,7 @@ function createStatsDimensionHelperStub () {
     'track-dev-id': TRACK_NAMES.DEVELOP,
     'track-design-id': TRACK_NAMES.DESIGN,
     'track-ds-id': TRACK_NAMES.DATA_SCIENCE,
-    'track-qa-id': 'Quality Assurance'
+    'track-qa-id': TRACK_NAMES.QA
   }
   const typeNamesById = {
     'type-challenge-id': TYPE_NAMES.CHALLENGE,
@@ -158,6 +160,9 @@ function createStatsDimensionHelperStub () {
       }
       if (normalized === 'DATA_SCIENCE' || normalized === 'DATA SCIENCE' || normalized === 'DS') {
         return TRACK_NAMES.DATA_SCIENCE
+      }
+      if (normalized === 'QUALITY_ASSURANCE' || normalized === 'QUALITY ASSURANCE' || normalized === 'QA') {
+        return TRACK_NAMES.QA
       }
       return value
     },
@@ -1041,7 +1046,7 @@ describe('statistics service unit tests', () => {
     }
   })
 
-  it('rerateChallengeSubmitterRatings should rate QA Challenge winners in the Testing bucket', async () => {
+  it('rerateChallengeSubmitterRatings should rate QA Challenge winners in the QA bucket', async () => {
     const qaRerateCalls = []
     const { service, restore } = loadStatisticsService({
       challengeRow: {
@@ -1091,8 +1096,8 @@ describe('statistics service unit tests', () => {
       result.participantIds.should.deep.equal(['89770374', '100000039'])
       result.ratings.should.deep.equal([
         {
-          trackId: 'DEVELOP',
-          typeId: 'BUG_HUNT'
+          trackId: 'QA',
+          typeId: 'Challenge'
         }
       ])
       qaRerateCalls.should.deep.equal([
@@ -1100,8 +1105,8 @@ describe('statistics service unit tests', () => {
           userId: '89770374',
           challengeId: 'qa-winner-only-challenge',
           options: {
-            targetTrackName: 'DEVELOP',
-            targetTypeName: 'BUG_HUNT',
+            targetTrackName: 'QA',
+            targetTypeName: 'Challenge',
             challengeTrackNames: ['QUALITY_ASSURANCE'],
             challengeTypeNames: ['Challenge']
           }
@@ -1110,8 +1115,8 @@ describe('statistics service unit tests', () => {
           userId: '100000039',
           challengeId: 'qa-winner-only-challenge',
           options: {
-            targetTrackName: 'DEVELOP',
-            targetTypeName: 'BUG_HUNT',
+            targetTrackName: 'QA',
+            targetTypeName: 'Challenge',
             challengeTrackNames: ['QUALITY_ASSURANCE'],
             challengeTypeNames: ['Challenge']
           }
@@ -2012,7 +2017,7 @@ describe('statistics service unit tests', () => {
     }
   })
 
-  it('getHistoryStats should surface QA challenge winner history under Testing', async () => {
+  it('getHistoryStats should surface QA challenge winner history under QA', async () => {
     const ratingDate = new Date('2026-06-15T08:00:00.000Z')
     const qaChallenge = {
       id: 'qa-challenge-june-15',
@@ -2028,8 +2033,8 @@ describe('statistics service unit tests', () => {
         memberStats: {
           findFirst: async () => null,
           findMany: async () => [{
-            trackId: 'track-dev-id',
-            typeId: 'type-bug-hunt-id'
+            trackId: 'track-qa-id',
+            typeId: 'type-challenge-id'
           }]
         },
         memberStatsHistory: {
@@ -2051,21 +2056,21 @@ describe('statistics service unit tests', () => {
       const result = await service.getHistoryStats({ isMachine: true }, 'devtest1400', {})
 
       result.should.have.length(1)
-      should.exist(result[0].DEVELOP)
-      result[0].DEVELOP.subTracks.should.have.length(1)
-      result[0].DEVELOP.subTracks[0].name.should.equal('BUG_HUNT')
-      result[0].DEVELOP.subTracks[0].history.should.have.length(1)
-      result[0].DEVELOP.subTracks[0].history[0].challengeId.should.equal('qa-challenge-june-15')
-      result[0].DEVELOP.subTracks[0].history[0].challengeName.should.equal('QA Challenge June 15')
-      result[0].DEVELOP.subTracks[0].history[0].placement.should.equal(1)
-      result[0].DEVELOP.subTracks[0].history[0].ratingDate.should.equal(ratingDate.getTime())
-      result[0].DEVELOP.subTracks[0].history[0].mostRecent.should.equal(true)
+      should.exist(result[0].QA)
+      result[0].QA.subTracks.should.have.length(1)
+      result[0].QA.subTracks[0].name.should.equal('Challenge')
+      result[0].QA.subTracks[0].history.should.have.length(1)
+      result[0].QA.subTracks[0].history[0].challengeId.should.equal('qa-challenge-june-15')
+      result[0].QA.subTracks[0].history[0].challengeName.should.equal('QA Challenge June 15')
+      result[0].QA.subTracks[0].history[0].placement.should.equal(1)
+      result[0].QA.subTracks[0].history[0].ratingDate.should.equal(ratingDate.getTime())
+      result[0].QA.subTracks[0].history[0].mostRecent.should.equal(true)
     } finally {
       restore()
     }
   })
 
-  it('getHistoryStats should remap persisted QA challenge history from Data Science to Testing', async () => {
+  it('getHistoryStats should remap persisted QA challenge history from Data Science to QA', async () => {
     const ratingDate = new Date('2026-06-15T08:00:00.000Z')
     const qaChallenge = {
       id: 'qa-challenge-june-15',
@@ -2107,16 +2112,16 @@ describe('statistics service unit tests', () => {
       const result = await service.getHistoryStats({ isMachine: true }, 'devtest1400', {})
 
       result.should.have.length(1)
-      should.exist(result[0].DEVELOP)
+      should.exist(result[0].QA)
       should.not.exist(result[0].DATA_SCIENCE)
-      result[0].DEVELOP.subTracks.should.have.length(1)
-      result[0].DEVELOP.subTracks[0].name.should.equal('BUG_HUNT')
-      result[0].DEVELOP.subTracks[0].history.should.have.length(1)
-      result[0].DEVELOP.subTracks[0].history[0].challengeId.should.equal('qa-challenge-june-15')
-      result[0].DEVELOP.subTracks[0].history[0].challengeName.should.equal('QA Challenge June 15')
-      result[0].DEVELOP.subTracks[0].history[0].rating.should.equal(1400)
-      result[0].DEVELOP.subTracks[0].history[0].placement.should.equal(1)
-      result[0].DEVELOP.subTracks[0].history[0].ratingDate.should.equal(ratingDate.getTime())
+      result[0].QA.subTracks.should.have.length(1)
+      result[0].QA.subTracks[0].name.should.equal('Challenge')
+      result[0].QA.subTracks[0].history.should.have.length(1)
+      result[0].QA.subTracks[0].history[0].challengeId.should.equal('qa-challenge-june-15')
+      result[0].QA.subTracks[0].history[0].challengeName.should.equal('QA Challenge June 15')
+      result[0].QA.subTracks[0].history[0].rating.should.equal(1400)
+      result[0].QA.subTracks[0].history[0].placement.should.equal(1)
+      result[0].QA.subTracks[0].history[0].ratingDate.should.equal(ratingDate.getTime())
     } finally {
       restore()
     }

--- a/test/unit/StatsDimensionHelper.test.js
+++ b/test/unit/StatsDimensionHelper.test.js
@@ -23,7 +23,8 @@ describe('stats dimension helper unit tests', () => {
       [
         { id: 'track-dev-id', name: 'Development', abbreviation: 'DEV', legacyId: null },
         { id: 'track-design-id', name: 'Design', abbreviation: 'DES', legacyId: null },
-        { id: 'track-ds-id', name: 'Data Science', abbreviation: 'DS', legacyId: null }
+        { id: 'track-ds-id', name: 'Data Science', abbreviation: 'DS', legacyId: null },
+        { id: 'track-qa-id', name: 'Quality Assurance', abbreviation: 'QA', legacyId: null }
       ],
       [
         { id: 'type-ch-id', name: 'Challenge', abbreviation: 'CH', legacyId: null, isTask: false },
@@ -35,10 +36,12 @@ describe('stats dimension helper unit tests', () => {
 
     resolveTrackIdFromLookup(lookup, 'DEVELOP').should.equal('track-dev-id')
     resolveTrackIdFromLookup(lookup, 'track-design-id').should.equal('track-design-id')
+    resolveTrackIdFromLookup(lookup, 'QUALITY_ASSURANCE').should.equal('track-qa-id')
     resolveTypeIdFromLookup(lookup, 'CH').should.equal('type-ch-id')
     resolveTypeIdFromLookup(lookup, TYPE_NAMES.TASK).should.equal('type-task-id')
     resolveTypeIdFromLookup(lookup, 118).should.equal('type-hidden-id')
     resolveTrackNameFromLookup(lookup, 'track-ds-id').should.equal(TRACK_NAMES.DATA_SCIENCE)
+    resolveTrackNameFromLookup(lookup, 'track-qa-id').should.equal(TRACK_NAMES.QA)
     resolveTypeNameFromLookup(lookup, 'type-hidden-id').should.equal('ARCHITECTURE')
     resolveTypeNameFromLookup(lookup, 'type-mm-id').should.equal(TYPE_NAMES.MARATHON_MATCH)
   })
@@ -150,6 +153,42 @@ describe('stats dimension helper unit tests', () => {
     })
   })
 
+  it('buildUnifiedStatsResponse should expose QA stats as a subtrack group', () => {
+    const result = prismaHelper.buildUnifiedStatsResponse(
+      {
+        userId: global.BigInt(88770025),
+        handle: 'devtest1400',
+        handleLower: 'devtest1400',
+        maxRating: null
+      },
+      [
+        {
+          groupId: global.BigInt(1),
+          trackId: 'track-qa-id',
+          typeId: 'type-ch-id',
+          trackName: TRACK_NAMES.QA,
+          typeName: TYPE_NAMES.CHALLENGE,
+          challenges: 1,
+          wins: 1,
+          rating: 1400,
+          volatility: 385,
+          mostRecentSubmission: new Date('2026-06-15T08:01:00.000Z'),
+          mostRecentEventDate: new Date('2026-06-15T08:00:00.000Z')
+        }
+      ]
+    )
+
+    should.exist(result.QA)
+    result.QA.challenges.should.equal(1)
+    result.QA.wins.should.equal(1)
+    result.QA.subTracks.should.have.length(1)
+    result.QA.subTracks[0].name.should.equal(TYPE_NAMES.CHALLENGE)
+    result.QA.subTracks[0].rank.should.deep.include({
+      rating: 1400,
+      volatility: 385
+    })
+  })
+
   it('buildUnifiedStatsResponse should display configured rating path names from deterministic type ids', () => {
     const result = prismaHelper.buildUnifiedStatsResponse(
       {
@@ -250,5 +289,38 @@ describe('stats dimension helper unit tests', () => {
     result.DEVELOP.subTracks[0].history[0].challengeId.should.equal('11111111-1111-1111-1111-111111111111')
     result.DEVELOP.subTracks[0].history[0].challengeName.should.equal('Specification Challenge')
     result.DEVELOP.subTracks[0].history[0].ratingDate.should.equal(ratingDate.getTime())
+  })
+
+  it('buildUnifiedStatsHistoryResponse should expose QA challenge history', () => {
+    const ratingDate = new Date('2026-06-15T08:00:00.000Z')
+    const result = prismaHelper.buildUnifiedStatsHistoryResponse(
+      {
+        userId: global.BigInt(88770025),
+        handle: 'devtest1400',
+        handleLower: 'devtest1400'
+      },
+      [
+        {
+          groupId: global.BigInt(1),
+          trackId: 'track-qa-id',
+          typeId: 'type-ch-id',
+          trackName: TRACK_NAMES.QA,
+          typeName: TYPE_NAMES.CHALLENGE,
+          challengeId: 'qa-challenge-june-15',
+          challengeName: 'QA Challenge June 15',
+          newRating: 1400,
+          placement: 1,
+          ratingDate,
+          mostRecent: true
+        }
+      ]
+    )
+
+    should.exist(result.QA)
+    result.QA.subTracks.should.have.length(1)
+    result.QA.subTracks[0].name.should.equal(TYPE_NAMES.CHALLENGE)
+    result.QA.subTracks[0].history.should.have.length(1)
+    result.QA.subTracks[0].history[0].challengeName.should.equal('QA Challenge June 15')
+    result.QA.subTracks[0].history[0].placement.should.equal(1)
   })
 })


### PR DESCRIPTION
What was broken
QA Challenge ratings and history were previously being forced into existing public buckets instead of using a QA stats dimension. The latest QA feedback asked for the QA track/type to be supported directly instead of using DEVELOP.

Root cause
The stats dimension resolver and unified stats response helpers did not treat QA as a supported canonical track, so follow-up fixes mapped Quality Assurance Challenge rows to DATA_SCIENCE or DEVELOP-based buckets.

What was changed
Added QA as a canonical stats track, routed Quality Assurance Challenge rerates and history normalization to QA / Challenge, exposed QA in unified stats/history/search responses, and updated the recalculation path to normalize QA Challenge aggregates to QA / Challenge.

Any added/updated tests
Updated rerating and history tests to expect QA / Challenge, added recalculate coverage for QA Challenge aggregates, and added formatter coverage for QA stats and QA history responses.
