### PR TITLE
PM-5392: Route AI Engineering ratings to develop

### DIFF
--- a/config/default.js
+++ b/config/default.js
@@ -17,7 +17,7 @@ if (!communicationSecureFields.includes('email')) {
 const defaultRatingPaths = [
   {
     name: 'AI Engineering',
-    track: 'DATA_SCIENCE',
+    track: 'DEVELOP',
     tags: ['AI', 'AI Exponential League']
   }
 ]

--- a/test/unit/StatisticsService.test.js
+++ b/test/unit/StatisticsService.test.js
@@ -753,7 +753,7 @@ describe('statistics service unit tests', () => {
       should.exist(capturedOptions)
       capturedOptions.ratingPath.name.should.equal('AI Engineering')
       capturedOptions.ratingPath.tags.should.deep.equal(['AI', 'AI Exponential League'])
-      result.trackId.should.equal('DATA_SCIENCE')
+      result.trackId.should.equal('DEVELOP')
       result.typeId.should.equal('AI Engineering')
       result.ratingName.should.equal('AI Engineering')
       result.ratingTags.should.deep.equal(['AI', 'AI Exponential League'])
@@ -876,7 +876,7 @@ describe('statistics service unit tests', () => {
           typeId: 'Challenge'
         },
         {
-          trackId: 'DATA_SCIENCE',
+          trackId: 'DEVELOP',
           typeId: 'AI Engineering',
           ratingName: 'AI Engineering',
           ratingTags: ['AI', 'AI Exponential League'],

--- a/test/unit/StatsDimensionHelper.test.js
+++ b/test/unit/StatsDimensionHelper.test.js
@@ -200,9 +200,9 @@ describe('stats dimension helper unit tests', () => {
       [
         {
           groupId: global.BigInt(1),
-          trackId: 'track-ds-id',
+          trackId: 'track-dev-id',
           typeId: 'rating-path-ai-engineering',
-          trackName: TRACK_NAMES.DATA_SCIENCE,
+          trackName: TRACK_NAMES.DEVELOP,
           challenges: 3,
           wins: null,
           rating: 1517,
@@ -213,13 +213,15 @@ describe('stats dimension helper unit tests', () => {
       ]
     )
 
-    should.exist(result.DATA_SCIENCE)
-    should.exist(result.DATA_SCIENCE['AI Engineering'])
-    should.not.exist(result.DATA_SCIENCE['rating-path-ai-engineering'])
-    result.DATA_SCIENCE['AI Engineering'].rank.should.deep.equal({
+    should.exist(result.DEVELOP)
+    result.DEVELOP.subTracks.should.have.length(1)
+    result.DEVELOP.subTracks[0].name.should.equal('AI Engineering')
+    result.DEVELOP.subTracks[0].rank.should.deep.equal({
       rating: 1517,
       volatility: 331
     })
+    should.not.exist(result.DATA_SCIENCE)
+    result.maxRating.track.should.equal(TRACK_NAMES.DEVELOP)
     result.maxRating.subTrack.should.equal('AI Engineering')
   })
 


### PR DESCRIPTION
What was broken
AI-tagged development challenges were configured to use the Data Science stats track, so member profile stats exposed AI Engineering ratings under DATA_SCIENCE.

Root cause
The default AI Engineering rating path in member-api-v6 was seeded with track DATA_SCIENCE even though the tagged challenges are development challenges.

What was changed
Changed the default AI Engineering rating path destination to DEVELOP so rerates and profile stats place those ratings under the development track.

Any added/updated tests
Updated stats response and rerate summary unit tests to assert AI Engineering rating path rows are exposed under DEVELOP.

Validation run:
- pnpm lint passed.
- pnpm exec mocha -t 20000 test/unit/StatsDimensionHelper.test.js test/unit/StatisticsService.test.js test/unit/MmRatingEngine.test.js --exit passed with 70 passing tests.
- pnpm test was attempted; it reached unrelated legacy DB-backed tests and failed on local fixture/environment issues outside PM-5392, including missing standardized skills tables, bus/Auth0 test configuration, and an existing communication secure-fields assertion.
- pnpm build was attempted; this package has no build script, so pnpm reported Command "build" not found.
