### PR TITLE
PM-5396: Surface AI Engineering stats history

### DIFF
--- a/src/services/StatisticsService.js
+++ b/src/services/StatisticsService.js
@@ -1115,6 +1115,12 @@ async function fetchChallengeWinnerResultsForMember (challengeClient, userId) {
             trackId: true,
             typeId: true,
             endDate: true,
+            tags: true,
+            skills: {
+              select: {
+                skillId: true
+              }
+            },
             legacyRecord: {
               select: {
                 legacySystemId: true
@@ -1200,6 +1206,7 @@ async function fetchChallengeMetadataMap (challengeClient, challengeIds) {
       trackId: true,
       typeId: true,
       endDate: true,
+      tags: true,
       track: {
         select: {
           name: true
@@ -1208,6 +1215,11 @@ async function fetchChallengeMetadataMap (challengeClient, challengeIds) {
       type: {
         select: {
           name: true
+        }
+      },
+      skills: {
+        select: {
+          skillId: true
         }
       },
       metadata: RATING_METADATA_SELECT,
@@ -1660,6 +1672,179 @@ function getMissingUnifiedHistoryPairKeys (aggregateRows, historyRows, dimension
       .filter(pairKey => !persistedPairKeys.has(pairKey))
       .value()
   )
+}
+
+/**
+ * Resolve a configured rating path represented by an annotated stats row.
+ * @param {Object} row annotated memberStats row with track/type ids and names
+ * @returns {Object|null} normalized rating path config for the row
+ */
+function resolveConfiguredRatingPathForStatsRow (row) {
+  const ratingPath = getConfiguredRatingPath(config.RATING_PATHS, row && (row.typeName || row.typeId)) ||
+    getConfiguredRatingPathByTypeId(config.RATING_PATHS, row && row.typeId)
+
+  if (!ratingPath || row.trackName !== ratingPath.trackName) {
+    return null
+  }
+
+  return ratingPath
+}
+
+/**
+ * Build a lookup of missing aggregate pairs that belong to configured rating paths.
+ * @param {Array<Object>} aggregateRows unified memberStats rows for one member
+ * @param {Object} dimensionLookup shared challenge dimension lookup
+ * @param {Set<string>} missingPairKeys track/type pairs still needing history
+ * @returns {Map<string, Object>} missing configured rating path pairs keyed by track/type
+ */
+function getMissingConfiguredRatingPathPairMap (aggregateRows, dimensionLookup, missingPairKeys) {
+  const pairMap = new Map()
+
+  if (!missingPairKeys || missingPairKeys.size === 0) {
+    return pairMap
+  }
+
+  _.forEach(annotateUnifiedDimensionRows(aggregateRows || [], dimensionLookup), (row) => {
+    const pairKey = buildStatsTrackTypeKey(row.trackId, row.typeId)
+    if (!missingPairKeys.has(pairKey) || !isSupportedUnifiedHistoryTrack(row.trackName)) {
+      return
+    }
+
+    const ratingPath = resolveConfiguredRatingPathForStatsRow(row)
+    if (!ratingPath) {
+      return
+    }
+
+    pairMap.set(pairKey, {
+      trackId: row.trackId,
+      typeId: row.typeId,
+      trackName: row.trackName,
+      typeName: ratingPath.name,
+      ratingPath
+    })
+  })
+
+  return pairMap
+}
+
+/**
+ * Build transient history rows for missing configured rating path pairs.
+ * @param {Array<Object>} entries challenge history source entries
+ * @param {Map<string, Object>} ratingPathPairMap configured rating path pairs to synthesize
+ * @returns {Array<Object>} synthesized configured rating path history rows
+ */
+function buildConfiguredRatingPathFallbackRows (entries, ratingPathPairMap) {
+  const ratingPathPairs = Array.from((ratingPathPairMap || new Map()).values())
+  if (ratingPathPairs.length === 0 || !entries || entries.length === 0) {
+    return []
+  }
+
+  const fallbackRowsByChallengeKey = new Map()
+
+  _.forEach(entries, (entry) => {
+    const challenge = entry && entry.challenge
+    if (!challenge || !isCompletedChallenge(challenge)) {
+      return
+    }
+
+    const challengeId = _.isNil(challenge.id) ? null : String(challenge.id).trim()
+    if (!challengeId) {
+      return
+    }
+
+    const eventDate = toOptionalDate(challenge.endDate || entry.createdAt)
+    if (!eventDate) {
+      return
+    }
+
+    const createdAt = toOptionalDate(entry.createdAt) || eventDate
+
+    _.forEach(ratingPathPairs, (pair) => {
+      if (!challengeMatchesRatingPath(challenge, pair.ratingPath)) {
+        return
+      }
+
+      const pairKey = buildStatsTrackTypeKey(pair.trackId, pair.typeId)
+      const challengeKey = `${pairKey}::${challengeId}`
+      const existing = fallbackRowsByChallengeKey.get(challengeKey)
+
+      if (existing && createdAt <= existing.createdAt) {
+        return
+      }
+
+      fallbackRowsByChallengeKey.set(challengeKey, {
+        trackId: pair.trackId,
+        typeId: pair.typeId,
+        trackName: pair.trackName,
+        typeName: pair.typeName,
+        challengeId,
+        challengeName: challenge.name || null,
+        eventDate,
+        placement: entry.placement,
+        createdAt
+      })
+    })
+  })
+
+  const fallbackRows = []
+  const rowsByPairKey = _.groupBy(Array.from(fallbackRowsByChallengeKey.values()), row => buildStatsTrackTypeKey(row.trackId, row.typeId))
+
+  _.forEach(rowsByPairKey, (pairRows) => {
+    const orderedRows = _.orderBy(pairRows, [
+      row => row.eventDate.getTime(),
+      row => row.createdAt.getTime(),
+      row => row.challengeId
+    ], ['desc', 'desc', 'desc'])
+
+    _.forEach(orderedRows, (row, index) => {
+      fallbackRows.push(_.omit({
+        ...row,
+        mostRecent: index === 0
+      }, ['createdAt']))
+    })
+  })
+
+  return fallbackRows
+}
+
+/**
+ * Build transient configured rating path rows from review-api challenge results.
+ * @param {Array<Object>} reviewRows review-api challenge results for the member
+ * @param {Map<string, Object>} challengeMetadataById challenge metadata keyed by UUID and legacy ids
+ * @param {Map<string, Object>} ratingPathPairMap configured rating path pairs to synthesize
+ * @returns {Array<Object>} synthesized configured rating path history rows
+ */
+function buildConfiguredRatingPathFallbackRowsFromReviewResults (
+  reviewRows,
+  challengeMetadataById,
+  ratingPathPairMap
+) {
+  const entries = _.chain(reviewRows || [])
+    .filter(isUsableReviewChallengeResultRow)
+    .map(row => ({
+      challenge: challengeMetadataById.get(String(row.challengeId)),
+      createdAt: row.createdAt,
+      placement: toVisiblePlacement(row.placement)
+    }))
+    .value()
+
+  return buildConfiguredRatingPathFallbackRows(entries, ratingPathPairMap)
+}
+
+/**
+ * Build transient configured rating path rows from challenge winner placements.
+ * @param {Array<Object>} winnerRows placement winner rows with embedded challenge metadata
+ * @param {Map<string, Object>} ratingPathPairMap configured rating path pairs to synthesize
+ * @returns {Array<Object>} synthesized configured rating path history rows
+ */
+function buildConfiguredRatingPathFallbackRowsFromChallengeWinners (winnerRows, ratingPathPairMap) {
+  const entries = _.map(winnerRows || [], row => ({
+    challenge: row.challenge,
+    createdAt: row.createdAt,
+    placement: toVisibleChallengeWinnerPlacement(row)
+  }))
+
+  return buildConfiguredRatingPathFallbackRows(entries, ratingPathPairMap)
 }
 
 /**
@@ -3465,14 +3650,25 @@ async function getHistoryStats (currentUser, handle, query) {
       ))
 
       if (unresolvedPairKeys.size > 0 && reviewRows.length > 0) {
+        const ratingPathPairMap = getMissingConfiguredRatingPathPairMap(
+          aggregateRows,
+          dimensionLookup,
+          unresolvedPairKeys
+        )
         const reviewFallbackRows = buildFallbackHistoryRowsFromReviewResults(
           reviewRows,
           challengeMetadataById,
           dimensionLookup,
           unresolvedPairKeys
         )
-        annotatedRows = mergeMissingHistoryRows(annotatedRows, reviewFallbackRows)
-        unresolvedPairKeys = getUnresolvedHistoryPairKeys(unresolvedPairKeys, reviewFallbackRows)
+        const ratingPathFallbackRows = buildConfiguredRatingPathFallbackRowsFromReviewResults(
+          reviewRows,
+          challengeMetadataById,
+          ratingPathPairMap
+        )
+        const fallbackRows = reviewFallbackRows.concat(ratingPathFallbackRows)
+        annotatedRows = mergeMissingHistoryRows(annotatedRows, fallbackRows)
+        unresolvedPairKeys = getUnresolvedHistoryPairKeys(unresolvedPairKeys, fallbackRows)
       }
 
       if (
@@ -3496,8 +3692,13 @@ async function getHistoryStats (currentUser, handle, query) {
           dimensionLookup,
           winnerFallbackPairKeys
         )
-        annotatedRows = mergeMissingHistoryRows(annotatedRows, winnerFallbackRows)
-        unresolvedPairKeys = getUnresolvedHistoryPairKeys(unresolvedPairKeys, winnerFallbackRows)
+        const ratingPathFallbackRows = buildConfiguredRatingPathFallbackRowsFromChallengeWinners(
+          winnerRows,
+          getMissingConfiguredRatingPathPairMap(aggregateRows, dimensionLookup, unresolvedPairKeys)
+        )
+        const fallbackRows = winnerFallbackRows.concat(ratingPathFallbackRows)
+        annotatedRows = mergeMissingHistoryRows(annotatedRows, fallbackRows)
+        unresolvedPairKeys = getUnresolvedHistoryPairKeys(unresolvedPairKeys, fallbackRows)
       }
 
       if (unresolvedPairKeys.size > 0) {

--- a/test/unit/StatisticsService.test.js
+++ b/test/unit/StatisticsService.test.js
@@ -728,6 +728,116 @@ describe('statistics service unit tests', () => {
     }
   })
 
+  it('getHistoryStats should synthesize configured rating path history for matching Data Science challenges', async () => {
+    const ratingDate = new Date('2026-06-17T11:28:39.672Z')
+    const aiChallenge = {
+      id: 'fd3472a8-b4d3-4ccc-ad95-d98937d3451a',
+      name: 'DS Ai',
+      status: 'COMPLETED',
+      trackId: 'track-ds-id',
+      typeId: 'type-challenge-id',
+      endDate: ratingDate,
+      track: { name: 'Data Science' },
+      type: { name: 'Challenge' },
+      tags: ['AI'],
+      skills: [],
+      metadata: []
+    }
+    const nonAiChallenge = {
+      id: '6358e018-88b8-49fa-a0b5-62a9badd98e7',
+      name: 'Missing ch test 3',
+      status: 'COMPLETED',
+      trackId: 'track-ds-id',
+      typeId: 'type-challenge-id',
+      endDate: new Date('2026-05-10T10:00:00.000Z'),
+      track: { name: 'Data Science' },
+      type: { name: 'Challenge' },
+      tags: ['Other'],
+      skills: [],
+      metadata: []
+    }
+    const { service, restore } = loadStatisticsService({
+      ratingPaths: [
+        { name: 'AI Engineering', track: 'DATA_SCIENCE', tags: ['AI'] }
+      ],
+      prismaStub: {
+        $queryRaw: async () => [],
+        memberStats: {
+          findMany: async () => [
+            {
+              trackId: 'track-ds-id',
+              typeId: 'type-challenge-id',
+              challenges: 2,
+              mostRecentSubmission: ratingDate,
+              mostRecentEventDate: ratingDate
+            },
+            {
+              trackId: 'track-ds-id',
+              typeId: 'rating-path-ai-engineering',
+              challenges: 1,
+              mostRecentSubmission: ratingDate,
+              mostRecentEventDate: ratingDate
+            }
+          ]
+        },
+        memberStatsHistory: {
+          findMany: async () => [
+            {
+              trackId: 'track-ds-id',
+              typeId: 'type-challenge-id',
+              challengeId: aiChallenge.id,
+              eventDate: ratingDate,
+              placement: 1,
+              mostRecent: true
+            },
+            {
+              trackId: 'track-ds-id',
+              typeId: 'type-challenge-id',
+              challengeId: nonAiChallenge.id,
+              eventDate: nonAiChallenge.endDate,
+              placement: 1,
+              mostRecent: false
+            }
+          ]
+        }
+      },
+      challengeRows: [aiChallenge, nonAiChallenge],
+      reviewRows: [
+        {
+          challengeId: aiChallenge.id,
+          userId: '88770025',
+          submissionId: 'sub-ds-ai',
+          finalScore: 100,
+          placement: 1,
+          validSubmission: true,
+          createdAt: ratingDate
+        },
+        {
+          challengeId: nonAiChallenge.id,
+          userId: '88770025',
+          submissionId: 'sub-non-ai',
+          finalScore: 95,
+          placement: 1,
+          validSubmission: true,
+          createdAt: nonAiChallenge.endDate
+        }
+      ]
+    })
+
+    try {
+      const result = await service.getHistoryStats({ isMachine: true }, 'devtest1400', {})
+
+      result.should.have.length(1)
+      result[0].DATA_SCIENCE.Challenge.history.map(row => row.challengeName)
+        .should.deep.equal(['DS Ai', 'Missing ch test 3'])
+      result[0].DATA_SCIENCE['AI Engineering'].history.should.have.length(1)
+      result[0].DATA_SCIENCE['AI Engineering'].history[0].challengeName.should.equal('DS Ai')
+      result[0].DATA_SCIENCE['AI Engineering'].history[0].placement.should.equal(1)
+    } finally {
+      restore()
+    }
+  })
+
   it('rerateMemberStats should route configured rating paths to the Marathon Match engine', async () => {
     let capturedOptions
     const { service, restore } = loadStatisticsService({


### PR DESCRIPTION
What was broken
AI-tagged Data Science challenges could have AI Engineering aggregate stats without matching AI Engineering history rows, so profile challenge details could not render them under Development > AI Engineering while preserving the native Data Science > Challenge history.

Root cause
The member stats history fallback only synthesized missing native track/type pairs. Configured rating path aggregate pairs were ignored, and the challenge metadata used by history fallback did not include tags or skills needed to match rating path configuration.

What was changed
Loaded challenge tags and skills for history fallback metadata. Added configured rating path history synthesis for missing aggregate pairs from review results and challenge winner rows when the challenge matches the configured rating path.

Any added/updated tests
Added coverage for Data Science challenges tagged AI to remain under DATA_SCIENCE.Challenge history while also appearing under DATA_SCIENCE["AI Engineering"] history for the profiles app to render under Development > AI Engineering.

Validation:
- pnpm exec mocha -t 20000 test/unit/StatisticsService.test.js --exit
- pnpm lint
- pnpm build attempted, but this repo does not define a build script
- pnpm test attempted; with dummy DB URLs it ran 146 non-DB tests successfully and failed only DB-backed MemberService/MemberTraitService hooks because no PostgreSQL server is available at localhost:5432
- Non-DB unit suite excluding MemberService.test.js and MemberTraitService.test.js passed with 146 tests
