### PR TITLE
PM-5457: Backfill duplicate challenge history display fields

### DIFF
--- a/src/common/prismaHelper.js
+++ b/src/common/prismaHelper.js
@@ -85,6 +85,101 @@ function getUnifiedTypeName (typeId) {
   return canonical || typeId
 }
 
+/**
+ * Normalize a challenge id used to match duplicate history rows across tracks.
+ * @param {*} value raw challenge id from a memberStatsHistory response row
+ * @returns {string|undefined} normalized challenge id when available
+ */
+function normalizeHistoryChallengeId (value) {
+  if (_.isNil(value)) {
+    return undefined
+  }
+
+  const challengeId = String(value).trim()
+  return challengeId || undefined
+}
+
+/**
+ * Normalize a history placement so only positive integer placements are copied.
+ * @param {*} value raw placement value from a history row
+ * @returns {number|undefined} visible placement when available
+ */
+function normalizeHistoryPlacement (value) {
+  const placement = _.toInteger(value)
+  return Number.isInteger(placement) && placement > 0 ? placement : undefined
+}
+
+/**
+ * Return the rating value that a history card can display.
+ * @param {Object} row unified history row
+ * @returns {*} newRating or rating when either value is available
+ */
+function getHistoryDisplayRating (row) {
+  return _.isNil(row && row.newRating) ? row && row.rating : row.newRating
+}
+
+/**
+ * Fill missing display fields on duplicate challenge history rows.
+ *
+ * A completed challenge can appear once under its source track and again under a
+ * configured rating path, for example DEVELOPMENT / Challenge and DATA_SCIENCE /
+ * AI Engineering. The source-track row may only have the challenge card metadata,
+ * while the rating-path row carries the placement and rating needed by profile
+ * details. Existing values are preserved and only missing placement/newRating
+ * fields are copied.
+ *
+ * @param {Array<Object>} rows unified history rows
+ * @returns {Array<Object>} history rows with duplicate display fields backfilled
+ */
+function fillMissingHistoryDisplayFields (rows) {
+  const displayFieldsByChallengeId = new Map()
+
+  _.forEach(rows || [], (row) => {
+    const challengeId = normalizeHistoryChallengeId(row && row.challengeId)
+    if (!challengeId) {
+      return
+    }
+
+    const placement = normalizeHistoryPlacement(row.placement)
+    const rating = getHistoryDisplayRating(row)
+    if (!placement && _.isNil(rating)) {
+      return
+    }
+
+    const existing = displayFieldsByChallengeId.get(challengeId) || {}
+    displayFieldsByChallengeId.set(challengeId, {
+      placement: placement && (!existing.placement || placement < existing.placement)
+        ? placement
+        : existing.placement,
+      rating: _.isNil(existing.rating) ? rating : existing.rating
+    })
+  })
+
+  return _.map(rows || [], (row) => {
+    const challengeId = normalizeHistoryChallengeId(row && row.challengeId)
+    const displayFields = challengeId ? displayFieldsByChallengeId.get(challengeId) : undefined
+    if (!displayFields) {
+      return row
+    }
+
+    const existingPlacement = normalizeHistoryPlacement(row.placement)
+    const placement = existingPlacement || displayFields.placement
+    const newRating = _.isNil(row.newRating) && !_.isNil(displayFields.rating)
+      ? displayFields.rating
+      : row.newRating
+
+    if (placement === existingPlacement && newRating === row.newRating) {
+      return row
+    }
+
+    return {
+      ...row,
+      placement,
+      newRating
+    }
+  })
+}
+
 function isUuidValue (value) {
   return uuidPattern.test(String(value || '').trim())
 }
@@ -823,7 +918,8 @@ function buildUnifiedStatsHistoryResponse (member, historyStats, fields) {
     }))
     .filter(row => _.includes(supportedUnifiedHistoryTrackNames, row.resolvedTrackName))
     .value()
-  const first = _.head(validRows) || {}
+  const displayRows = fillMissingHistoryDisplayFields(validRows)
+  const first = _.head(displayRows) || {}
   const item = {
     userId: helper.bigIntToNumber(member.userId),
     groupId: helper.bigIntToNumber(first.groupId),
@@ -831,7 +927,7 @@ function buildUnifiedStatsHistoryResponse (member, historyStats, fields) {
     handleLower: member.handleLower
   }
 
-  const groupedByTrackType = _.groupBy(validRows, row => `${row.resolvedTrackName}::${row.resolvedTypeName}`)
+  const groupedByTrackType = _.groupBy(displayRows, row => `${row.resolvedTrackName}::${row.resolvedTypeName}`)
   _.forEach(groupedByTrackType, (trackHistory, key) => {
     const [trackName, typeName] = key.split('::')
     if (_.includes(groupedSubTrackStatsTrackNames, trackName)) {

--- a/test/unit/StatsDimensionHelper.test.js
+++ b/test/unit/StatsDimensionHelper.test.js
@@ -329,6 +329,78 @@ describe('stats dimension helper unit tests', () => {
     result.DEVELOP.subTracks[0].history[0].ratingDate.should.equal(ratingDate.getTime())
   })
 
+  it('buildUnifiedStatsHistoryResponse should fill missing challenge history display fields from duplicate rating paths', () => {
+    const firstRatingDate = new Date('2026-05-01T00:00:00.000Z')
+    const secondRatingDate = new Date('2026-05-02T00:00:00.000Z')
+    const result = prismaHelper.buildUnifiedStatsHistoryResponse(
+      {
+        userId: global.BigInt(15391415),
+        handle: 'winterflame',
+        handleLower: 'winterflame'
+      },
+      [
+        {
+          groupId: global.BigInt(1),
+          trackId: 'track-dev-id',
+          typeId: 'type-challenge-id',
+          trackName: TRACK_NAMES.DEVELOP,
+          typeName: TYPE_NAMES.CHALLENGE,
+          challengeId: 'ai-profile-pipeline',
+          challengeName: 'AI-Powered Topcoder Member Profile Video Pipeline',
+          eventDate: firstRatingDate,
+          mostRecent: false
+        },
+        {
+          groupId: global.BigInt(1),
+          trackId: 'track-ds-id',
+          typeId: 'rating-path-ai-engineering',
+          trackName: TRACK_NAMES.DATA_SCIENCE,
+          typeName: 'AI Engineering',
+          challengeId: 'ai-profile-pipeline',
+          challengeName: 'AI-Powered Topcoder Member Profile Video Pipeline',
+          newRating: 1180,
+          placement: 4,
+          eventDate: firstRatingDate,
+          mostRecent: false
+        },
+        {
+          groupId: global.BigInt(1),
+          trackId: 'track-dev-id',
+          typeId: 'type-challenge-id',
+          trackName: TRACK_NAMES.DEVELOP,
+          typeName: TYPE_NAMES.CHALLENGE,
+          challengeId: 'cognitive-diplomat',
+          challengeName: 'Cognitive Diplomat: Negotiation Next-Turn Predictor',
+          newRating: 1357,
+          eventDate: secondRatingDate,
+          mostRecent: true
+        },
+        {
+          groupId: global.BigInt(1),
+          trackId: 'track-ds-id',
+          typeId: 'rating-path-ai-engineering',
+          trackName: TRACK_NAMES.DATA_SCIENCE,
+          typeName: 'AI Engineering',
+          challengeId: 'cognitive-diplomat',
+          challengeName: 'Cognitive Diplomat: Negotiation Next-Turn Predictor',
+          newRating: 1225,
+          placement: 5,
+          eventDate: secondRatingDate,
+          mostRecent: true
+        }
+      ]
+    )
+
+    const developmentHistory = result.DEVELOP.subTracks[0].history
+    developmentHistory[0].newRating.should.equal(1180)
+    developmentHistory[0].rating.should.equal(1180)
+    developmentHistory[0].placement.should.equal(4)
+    developmentHistory[1].newRating.should.equal(1357)
+    developmentHistory[1].rating.should.equal(1357)
+    developmentHistory[1].placement.should.equal(5)
+    result.DATA_SCIENCE['AI Engineering'].history[0].placement.should.equal(4)
+  })
+
   it('buildUnifiedStatsHistoryResponse should expose QA challenge history', () => {
     const ratingDate = new Date('2026-06-15T08:00:00.000Z')
     const result = prismaHelper.buildUnifiedStatsHistoryResponse(


### PR DESCRIPTION
What was broken
Development challenge history cards could render without placement or rating even when the same challenge had those display values under a configured rating path such as DATA_SCIENCE / AI Engineering.

Root cause (if identifiable)
The stats history response grouped duplicate challenge rows by track and type without sharing display fields between the source-track row and the rating-path row. Profile pages that displayed the source-track history saw the metadata-only row and rendered blank stats.

What was changed
The unified stats history response now backfills only missing placement and newRating values from another history row with the same challenge id. Existing values are preserved, so a source-track rating is not overwritten by a rating-path rating.

Any added/updated tests
Added a stats history unit test covering duplicate Development / Challenge and DATA_SCIENCE / AI Engineering rows, including preserving an existing Development rating while copying missing placement.

Validation run:
- pnpm exec mocha -t 20000 test/unit/StatsDimensionHelper.test.js --exit passed.
- pnpm lint passed.
- pnpm test ran with placeholder Prisma URLs and reported 152 passing tests, then failed four DB-backed member service hooks because no PostgreSQL server was available at localhost:5432.
- pnpm build could not run because this package does not define a build command.
