### PR TITLE
PM-5679: Align special role summary counts

### DIFF
--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -1647,15 +1647,16 @@ paths:
         - Statistics
       description: >
         Get the count-only Copilot and Reviewer special-role summary displayed
-        on a member profile. Counts are distinct resource challenge IDs. A
-        challenge with more than one matching reviewer role is counted once,
-        and a role key is omitted when its count is zero. Reviewer assignments
-        include exactly Iterative Reviewer, Primary Reviewer, Reviewer, Failure
-        Reviewer, Final Reviewer, Aggregator, Stress Reviewer, Accuracy
-        Reviewer, Primary Screener, Checkpoint Screener, and Checkpoint
-        Reviewer. Copilot assignments use the Copilot resource role. This cheap
-        summary reads only the resources schema and does not load challenge
-        names or Copilot track/fulfillment details.
+        on a member profile. Counts use the same anonymous-visible challenge
+        set as the role detail endpoints: challenges have no groups, no
+        user-whitelist rows, and are not tasks. A challenge with more than one
+        matching reviewer role is counted once, and a role key is omitted when
+        its count is zero. Reviewer assignments include exactly Iterative
+        Reviewer, Primary Reviewer, Reviewer, Failure Reviewer, Final Reviewer,
+        Aggregator, Stress Reviewer, Accuracy Reviewer, Primary Screener,
+        Checkpoint Screener, and Checkpoint Reviewer. Copilot assignments use
+        the Copilot resource role. The summary does not load challenge names or
+        Copilot track/fulfillment details.
 
         Authorization:
           - Public: Anonymous callers may retrieve the count-only summary.
@@ -1676,6 +1677,10 @@ paths:
             $ref: '#/definitions/ErrorModel'
         '404':
           description: Member not found
+          schema:
+            $ref: '#/definitions/ErrorModel'
+        '503':
+          description: Required co-located challenges/resources schemas are unavailable
           schema:
             $ref: '#/definitions/ErrorModel'
         '500':
@@ -1710,10 +1715,10 @@ paths:
         excluded, a zero denominator returns 0, and the percentage is rounded
         to two decimal places on a 0-100 scale.
 
-        Cross-schema detail queries require the `challenges` and `resources`
+        Cross-schema special-role queries require the `challenges` and `resources`
         schemas to be co-located in the challenge database, as in the supported
         deployment. A split-database deployment receives `503 Service
-        Unavailable` for details while the resource-only summary remains usable.
+        Unavailable` for summary and detail requests.
 
         Authorization:
           - Public: Anonymous callers may retrieve anonymous-visible challenges.
@@ -2823,7 +2828,7 @@ definitions:
     type: object
     description: >
       Count-only special-role summary. `copilot` and `reviewer` are omitted when
-      their distinct resource challenge count is zero.
+      their anonymous-visible distinct challenge count is zero.
     properties:
       copilot:
         $ref: '#/definitions/SpecialRoleCount'
@@ -2838,7 +2843,7 @@ definitions:
         type: integer
         format: int32
         minimum: 1
-        description: Distinct resource challenge count for this role family.
+        description: Anonymous-visible distinct challenge count for this role family.
   SpecialRoleTrackCounts:
     type: object
     description: >

--- a/src/services/SpecialRoleService.ts
+++ b/src/services/SpecialRoleService.ts
@@ -1,9 +1,8 @@
 /**
  * Provides public profile statistics for a member's Copilot and Reviewer
- * challenge assignments. Summary counts stay in the resources database, while
- * detail queries join the resources and challenges schemas so visibility
- * filtering, sorting, and pagination remain database-bound for members with
- * thousands of role assignments.
+ * challenge assignments. Summary and detail queries join the resources and
+ * challenges schemas so visibility filtering, sorting, and pagination remain
+ * database-bound for members with thousands of role assignments.
  */
 
 const _ = require('lodash')
@@ -13,7 +12,7 @@ const logger = require('../common/logger')
 const errors = require('../common/errors')
 const prismaManager = require('../common/prisma')
 
-const { ChallengesPrisma, ResourcesPrisma } = prismaManager
+const { ChallengesPrisma } = prismaManager
 
 const COPILOT_ROLE = 'copilot'
 const REVIEWER_ROLE = 'reviewer'
@@ -39,8 +38,6 @@ const ROLE_NAMES_LOWER = {
   [COPILOT_ROLE]: [COPILOT_ROLE],
   [REVIEWER_ROLE]: REVIEWER_ROLE_NAMES_LOWER
 }
-const ALL_ROLE_NAMES_LOWER = [COPILOT_ROLE, ...REVIEWER_ROLE_NAMES_LOWER]
-
 const TRACK_KEY_BY_NORMALIZED_NAME = {
   DEVELOPMENT: 'DEVELOPMENT',
   DEVELOP: 'DEVELOPMENT',
@@ -56,8 +53,8 @@ const TRACK_KEY_BY_NORMALIZED_NAME = {
 /**
  * Execute a challenge-client raw query and turn a missing cross-schema relation
  * into an explicit service-availability error. Supported deployments co-locate
- * the `challenges` and `resources` schemas; split-database deployments can still
- * use the resource-only summary but cannot safely paginate visible details.
+ * the `challenges` and `resources` schemas; split-database deployments cannot
+ * safely calculate anonymous-visible summary or detail results.
  * @param {Object} query parameterized ChallengesPrisma SQL fragment
  * @returns {Promise<Array<Object>>} raw PostgreSQL result rows
  * @throws {ServiceUnavailableError} when required cross-schema tables are absent
@@ -76,7 +73,7 @@ async function runChallengeCrossSchemaQuery (query) {
       databaseMessage.includes('does not exist')
     ) {
       throw new errors.ServiceUnavailableError(
-        'Special role challenge details require the challenges and resources schemas to be co-located.'
+        'Special role queries require the challenges and resources schemas to be co-located.'
       )
     }
     throw error
@@ -127,48 +124,6 @@ function buildFulfillment (completed, cancelled) {
     total,
     rate: total > 0 ? Number(((completed / total) * 100).toFixed(2)) : 0
   }
-}
-
-/**
- * Count distinct resource challenges for both special-role families without
- * joining challenge details. The main profile summary uses this resource-only
- * query so restricted challenges still contribute to the role badge count and
- * long histories are reduced to two scalar rows in PostgreSQL.
- * @param {BigInt|Number|String} userId member user ID from the members database
- * @returns {Promise<Object>} `copilot` and `reviewer` distinct resource counts
- * @throws {Error} propagates resources database query failures
- */
-async function loadRoleCounts (userId) {
-  const rows = await prismaManager.getResourcesClient().$queryRaw(ResourcesPrisma.sql`
-    WITH "specialRoleChallenges" AS (
-      SELECT
-        CASE
-          WHEN resourceRole."nameLower" = ${COPILOT_ROLE} THEN ${COPILOT_ROLE}
-          ELSE ${REVIEWER_ROLE}
-        END AS "role",
-        resource."challengeId"
-      FROM resources."Resource" AS resource
-      INNER JOIN resources."ResourceRole" AS resourceRole
-        ON resourceRole."id" = resource."roleId"
-      WHERE resource."memberId" = ${String(userId)}
-        AND resourceRole."nameLower" IN (${ResourcesPrisma.join(ALL_ROLE_NAMES_LOWER)})
-      GROUP BY 1, resource."challengeId"
-    )
-    SELECT "role", COUNT(*)::int AS "challengeCount"
-    FROM "specialRoleChallenges"
-    GROUP BY "role"
-  `)
-
-  const counts = {
-    [COPILOT_ROLE]: 0,
-    [REVIEWER_ROLE]: 0
-  }
-  _.forEach(rows, row => {
-    if (_.includes(SPECIAL_ROLES, row.role)) {
-      counts[row.role] = Number(row.challengeCount) || 0
-    }
-  })
-  return counts
 }
 
 /**
@@ -226,7 +181,8 @@ function buildVisibleRoleChallengesCte (userId, role) {
  * @param {BigInt|Number|String} userId member user ID from the members database
  * @param {String} role `copilot` or `reviewer`
  * @returns {Promise<Number>} visible distinct challenge count
- * @throws {Error} propagates resources database query failures
+ * @throws {ServiceUnavailableError} when required cross-schema tables are absent
+ * @throws {Error} propagates challenge database query failures
  */
 async function countVisibleRoleChallenges (userId, role) {
   const roleChallengesCte = buildVisibleRoleChallengesCte(userId, role)
@@ -376,17 +332,26 @@ function formatChallenge (challenge) {
 }
 
 /**
- * Get cheap public Copilot and Reviewer badge counts for a member profile.
- * Roles with no distinct resource challenges are omitted, and challenges with
- * multiple reviewer assignments count once. No challenge names are loaded.
+ * Get public Copilot and Reviewer badge counts for a member profile. The
+ * summary reuses the detail view's anonymous-visible challenge set so its
+ * counts match the role details. Roles with no visible challenges are omitted,
+ * and challenges with multiple reviewer assignments count once.
  * @param {String} handle member handle resolved through the members table
  * @returns {Promise<Object>} optional count-only Copilot/Reviewer summaries
  * @throws {NotFoundError} when the member handle does not exist
- * @throws {Error} propagates resources database lookup failures
+ * @throws {ServiceUnavailableError} when required cross-schema tables are absent
+ * @throws {Error} propagates challenge database query failures
  */
 async function getMemberRoleStats (handle) {
   const member = await helper.getMemberByHandle(handle)
-  const counts = await loadRoleCounts(member.userId)
+  const [copilotCount, reviewerCount] = await Promise.all([
+    countVisibleRoleChallenges(member.userId, COPILOT_ROLE),
+    countVisibleRoleChallenges(member.userId, REVIEWER_ROLE)
+  ])
+  const counts = {
+    [COPILOT_ROLE]: copilotCount,
+    [REVIEWER_ROLE]: reviewerCount
+  }
   const result = {}
 
   if (counts[COPILOT_ROLE] > 0) {
@@ -412,7 +377,8 @@ getMemberRoleStats.schema = {
  * @returns {Promise<Object>} internally consistent paginated challenge result
  * @throws {NotFoundError} when the member handle does not exist
  * @throws {ValidationError} when role or pagination input is invalid
- * @throws {Error} propagates resources database lookup failures
+ * @throws {ServiceUnavailableError} when required cross-schema tables are absent
+ * @throws {Error} propagates challenge database query failures
  */
 async function getMemberRoleChallenges (handle, role, query: any = {}) {
   const member = await helper.getMemberByHandle(handle)

--- a/test/unit/SpecialRoleService.test.js
+++ b/test/unit/SpecialRoleService.test.js
@@ -143,31 +143,33 @@ describe('special role service unit tests', () => {
     delete require.cache[servicePath]
   })
 
-  it('getMemberRoleStats should return resource-only distinct counts for exact role families', async () => {
-    let resourceSql
-    let challengeQueryCalled = false
+  it('getMemberRoleStats should return anonymous-visible counts for exact role families', async () => {
+    const challengeSql = []
+    let resourceQueryCalled = false
     const { service, restore } = loadSpecialRoleService({
-      onResourceQuery: async (sql) => {
-        resourceSql = sql
-        return [
-          { role: 'copilot', challengeCount: 4 },
-          { role: 'reviewer', challengeCount: 3 }
-        ]
-      },
-      onChallengeQuery: async () => {
-        challengeQueryCalled = true
+      onResourceQuery: async () => {
+        resourceQueryCalled = true
         return []
+      },
+      onChallengeQuery: async (sql) => {
+        challengeSql.push(sql)
+        return [{ challengeCount: sql.includes('copilot') ? 4 : 3 }]
       }
     })
 
     try {
       const result = await service.getMemberRoleStats('devtest1400')
+      const allSql = challengeSql.join('\n')
 
-      resourceSql.should.include('COUNT(*)::int AS "challengeCount"')
-      resourceSql.should.include('GROUP BY 1, resource."challengeId"')
-      resourceSql.should.include('copilot')
-      REVIEWER_ROLE_NAMES.forEach(roleName => resourceSql.should.include(roleName))
-      should.equal(challengeQueryCalled, false)
+      challengeSql.length.should.equal(2)
+      allSql.should.include('COUNT(*)::int AS "challengeCount"')
+      allSql.should.include('GROUP BY resource."challengeId"')
+      allSql.should.include('cardinality(challenge."groups") = 0')
+      allSql.should.include('challenge."taskIsTask" = FALSE')
+      allSql.should.include('challenges."ChallengeUserWhitelist"')
+      allSql.should.include('copilot')
+      REVIEWER_ROLE_NAMES.forEach(roleName => allSql.should.include(roleName))
+      should.equal(resourceQueryCalled, false)
       result.should.deep.equal({
         copilot: { challengeCount: 4 },
         reviewer: { challengeCount: 3 }
@@ -347,15 +349,39 @@ describe('special role service unit tests', () => {
     }
   })
 
-  it('getMemberRoleStats should omit role keys with zero resource challenges', async () => {
+  it('getMemberRoleStats should omit role keys with zero visible challenges', async () => {
     const { service, restore } = loadSpecialRoleService({
-      onResourceQuery: async () => [{ role: 'reviewer', challengeCount: 2 }],
-      onChallengeQuery: async () => []
+      onResourceQuery: async () => [],
+      onChallengeQuery: async sql => [{
+        challengeCount: sql.includes('copilot') ? 0 : 2
+      }]
     })
 
     try {
       const result = await service.getMemberRoleStats('devtest1400')
       result.should.deep.equal({ reviewer: { challengeCount: 2 } })
+    } finally {
+      restore()
+    }
+  })
+
+  it('getMemberRoleStats should explain missing co-located schemas', async () => {
+    const missingRelationError = new Error('relation does not exist')
+    missingRelationError.code = 'P2010'
+    missingRelationError.meta = { code: '3F000' }
+    const { service, restore } = loadSpecialRoleService({
+      onResourceQuery: async () => [],
+      onChallengeQuery: async () => {
+        throw missingRelationError
+      }
+    })
+
+    try {
+      await service.getMemberRoleStats('devtest1400')
+      should.fail('Expected a service availability error')
+    } catch (error) {
+      error.httpStatus.should.equal(503)
+      error.message.should.include('schemas to be co-located')
     } finally {
       restore()
     }


### PR DESCRIPTION
## What was broken

For some members, the Copilot and Reviewer counts shown on the profile summary were higher than the totals returned by the corresponding details view.

## Root cause (if identifiable)

The summary counted all distinct resource assignments, including restricted, task, and orphaned challenges. The details endpoint joined challenge data and applied anonymous visibility filtering, so the two endpoints counted different sets.

## What was changed

- Reused the details endpoint's anonymous-visible challenge query for both summary role counts.
- Preserved distinct counting across the exact Copilot and Reviewer role families.
- Documented the shared visibility rules and cross-schema availability response.

## Any added/updated tests

Updated special-role service tests to verify matching visible summary counts and added summary coverage for unavailable co-located schemas.

Validation completed:

- Targeted special-role tests: 6 tests passed.
- `pnpm lint` passed.
- `pnpm build` passed.
- The full `pnpm test` command also ran against isolated local dependencies; 203 tests passed and 28 failures remained in unrelated MemberService/MemberTrait validation coverage outside the changed special-role files.
