### PR TITLE
PM-5788: Allow Autopilot to sync profile points

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -174,6 +174,10 @@ Content-Type: application/json
 }
 ```
 
+The endpoint accepts M2M tokens with `refresh:member_stats`, `update:user_profiles`,
+or `all:user_profiles`. Autopilot uses the stats refresh scope when synchronizing
+completed challenge results. User tokens require the `administrator` or `admin` role.
+
 `GET /v6/members/{handle}` includes a public `challengePoints` object by default:
 
 ```json

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -182,7 +182,8 @@ paths:
         Replace the stored point awards for one challenge. This endpoint mirrors point-based challenge prize payouts into member-api so member profiles can return challenge point totals and per-challenge details.
 
         Authorization:
-          - M2M scopes: `update:user_profiles` or `all:user_profiles`.
+          - M2M scopes: `update:user_profiles`, `refresh:member_stats`, or `all:user_profiles`.
+          - User roles: `administrator` or `admin`.
       security:
         - bearer: []
       parameters:

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -73,7 +73,8 @@ module.exports = {
       controller: 'MemberController',
       method: 'updateChallengePoints',
       auth: 'jwt',
-      scopes: [MEMBERS.UPDATE, MEMBERS.ALL]
+      scopes: [MEMBERS.UPDATE, STATS_REFRESH, MEMBERS.ALL],
+      access: constants.ADMIN_ROLES
     }
   },
   '/members/:handle': {

--- a/test/unit/AppRoutes.test.js
+++ b/test/unit/AppRoutes.test.js
@@ -69,6 +69,18 @@ describe('app routes unit tests', () => {
     delete require.cache[appRoutesPath]
   })
 
+  it('challenge points route should accept stats refresh M2M calls and restrict user calls to admins', () => {
+    const config = require(configPath)
+    const routes = require(routesPath)
+    const challengePointsRoute = routes['/members/challenge-points/:challengeId'].put
+    const scopes = challengePointsRoute.scopes
+
+    scopes.should.include(config.SCOPES.MEMBERS.UPDATE)
+    scopes.should.include(config.SCOPES.MEMBERS.STATS_REFRESH)
+    scopes.should.include(config.SCOPES.MEMBERS.ALL)
+    challengePointsRoute.access.should.deep.equal(['administrator', 'admin'])
+  })
+
   it('public routes should skip optional JWT authentication when no authorization header is present', async () => {
     const originalEntries = {
       [appRoutesPath]: require.cache[appRoutesPath],


### PR DESCRIPTION
## What was broken

Completed point challenges generated finance winnings, but winning member profiles retained an empty `challengePoints` summary. Profiles therefore hid the Points section, including for the reported member.

## Root cause

Autopilot uses its existing `refresh:member_stats` M2M scope when it calls the member challenge-points endpoint after challenge completion. The endpoint accepted only `update:user_profiles` or `all:user_profiles`, so the automatic sync was rejected before member point rows could be stored.

## What was changed

- Allowed `refresh:member_stats` on `PUT /members/challenge-points/:challengeId` while preserving the existing profile scopes.
- Restricted user-token access on this internal write route to the existing administrator roles; M2M authorization remains scope-based.
- Updated the README and Swagger authorization documentation.

## Any added/updated tests

- Added a route contract regression test covering the accepted M2M scopes and admin-only user access.
- Focused AppRoutes tests: 2 passing.
- Existing challenge-point persistence tests: 2 passing.
- `pnpm lint`: passed.
- `pnpm build`: passed.
- Full `pnpm test`: 205 passing and 28 unrelated existing failures. Those failures require bus Auth0 credentials or update stale Joi error-message expectations; none exercise the changed route or challenge-point persistence.
